### PR TITLE
feat: 일일, 월별, 카테고리별 통계 API 구현 (#14)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ main ]
 
+env:
+  SERVER_PORT: ${{ secrets.SERVER_PORT }}
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/backend/src/main/java/com/pigma/harusari/statistics/common/StatisticsType.java
+++ b/backend/src/main/java/com/pigma/harusari/statistics/common/StatisticsType.java
@@ -1,0 +1,9 @@
+package com.pigma.harusari.statistics.common;
+
+public enum StatisticsType {
+
+    DAILY,
+    MONTHLY,
+    CATEGORY
+
+}

--- a/backend/src/main/java/com/pigma/harusari/statistics/query/controller/StatisticsController.java
+++ b/backend/src/main/java/com/pigma/harusari/statistics/query/controller/StatisticsController.java
@@ -1,6 +1,7 @@
 package com.pigma.harusari.statistics.query.controller;
 
 import com.pigma.harusari.common.dto.ApiResponse;
+import com.pigma.harusari.statistics.query.dto.response.StatisticsCategoryResponse;
 import com.pigma.harusari.statistics.query.dto.response.StatisticsDayResponse;
 import com.pigma.harusari.statistics.query.dto.response.StatisticsMonthResponse;
 import com.pigma.harusari.statistics.query.service.StatisticsService;
@@ -57,6 +58,17 @@ public class StatisticsController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResponse.success(statisticsMonthly));
+    }
+
+    @GetMapping("/statistics/category")
+    public ResponseEntity<ApiResponse<StatisticsCategoryResponse>> getStatisticsCategory() {
+        Long memberId = 1L; // 스프링 시큐리티 구현 완료되면 변경할 예정
+
+        StatisticsCategoryResponse statisticsCategory = statisticsService.getStatisticsCategory(memberId);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(statisticsCategory));
     }
 
 }

--- a/backend/src/main/java/com/pigma/harusari/statistics/query/controller/StatisticsController.java
+++ b/backend/src/main/java/com/pigma/harusari/statistics/query/controller/StatisticsController.java
@@ -2,6 +2,7 @@ package com.pigma.harusari.statistics.query.controller;
 
 import com.pigma.harusari.common.dto.ApiResponse;
 import com.pigma.harusari.statistics.query.dto.response.StatisticsDayResponse;
+import com.pigma.harusari.statistics.query.dto.response.StatisticsMonthResponse;
 import com.pigma.harusari.statistics.query.service.StatisticsService;
 import com.pigma.harusari.statistics.query.utils.StatisticsRequestParser;
 import jakarta.annotation.Nullable;
@@ -38,6 +39,24 @@ public class StatisticsController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResponse.success(statisticsDaily));
+    }
+
+    @GetMapping("/statistics/monthly")
+    public ResponseEntity<ApiResponse<StatisticsMonthResponse>> getStatisticsMonthly(
+            @RequestParam(value = "date") @Nullable String date
+    ) {
+        LocalDate parseDate = StatisticsRequestParser.parseDate(date);
+
+        Long memberId = 1L; // 스프링 시큐리티 구현 완료되면 변경할 예정
+
+        LocalDateTime startDateTime = parseDate.withDayOfMonth(1).atStartOfDay();
+        LocalDateTime endDateTime = parseDate.plusMonths(1).withDayOfMonth(1).atStartOfDay();
+
+        StatisticsMonthResponse statisticsMonthly = statisticsService.getStatisticsMonthly(memberId, startDateTime, endDateTime);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(statisticsMonthly));
     }
 
 }

--- a/backend/src/main/java/com/pigma/harusari/statistics/query/controller/StatisticsController.java
+++ b/backend/src/main/java/com/pigma/harusari/statistics/query/controller/StatisticsController.java
@@ -1,0 +1,43 @@
+package com.pigma.harusari.statistics.query.controller;
+
+import com.pigma.harusari.common.dto.ApiResponse;
+import com.pigma.harusari.statistics.query.dto.response.StatisticsDayResponse;
+import com.pigma.harusari.statistics.query.service.StatisticsService;
+import com.pigma.harusari.statistics.query.utils.StatisticsRequestParser;
+import jakarta.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class StatisticsController {
+
+    private static final long ONE_DAY = 1L;
+
+    private final StatisticsService statisticsService;
+
+    @GetMapping("/statistics/daily")
+    public ResponseEntity<ApiResponse<StatisticsDayResponse>> getStatisticsDaily(
+            @RequestParam(value = "date") @Nullable String date
+    ) {
+        LocalDate parseDate = StatisticsRequestParser.parseDate(date);
+
+        Long memberId = 1L; // 스프링 시큐리티 구현 완료되면 변경할 예정
+
+        LocalDateTime startDateTime = parseDate.atStartOfDay();
+        LocalDateTime endDateTime = parseDate.plusDays(ONE_DAY).atStartOfDay();
+
+        StatisticsDayResponse statisticsDaily = statisticsService.getStatisticsDaily(memberId, startDateTime, endDateTime);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(statisticsDaily));
+    }
+
+}

--- a/backend/src/main/java/com/pigma/harusari/statistics/query/dto/response/StatisticsCategoryRateResponse.java
+++ b/backend/src/main/java/com/pigma/harusari/statistics/query/dto/response/StatisticsCategoryRateResponse.java
@@ -1,0 +1,10 @@
+package com.pigma.harusari.statistics.query.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record StatisticsCategoryRateResponse(
+        String categoryName,
+        double achievementRate
+) {
+}

--- a/backend/src/main/java/com/pigma/harusari/statistics/query/dto/response/StatisticsCategoryResponse.java
+++ b/backend/src/main/java/com/pigma/harusari/statistics/query/dto/response/StatisticsCategoryResponse.java
@@ -1,0 +1,12 @@
+package com.pigma.harusari.statistics.query.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record StatisticsCategoryResponse(
+        String type,
+        List<StatisticsCategoryRateResponse> categoryRates
+) {
+}

--- a/backend/src/main/java/com/pigma/harusari/statistics/query/dto/response/StatisticsDailyRateResponse.java
+++ b/backend/src/main/java/com/pigma/harusari/statistics/query/dto/response/StatisticsDailyRateResponse.java
@@ -1,0 +1,9 @@
+package com.pigma.harusari.statistics.query.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record StatisticsDailyRateResponse(
+    double achievementRate
+) {
+}

--- a/backend/src/main/java/com/pigma/harusari/statistics/query/dto/response/StatisticsDayResponse.java
+++ b/backend/src/main/java/com/pigma/harusari/statistics/query/dto/response/StatisticsDayResponse.java
@@ -1,0 +1,9 @@
+package com.pigma.harusari.statistics.query.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record StatisticsDayResponse(
+        double achievementRate
+) {
+}

--- a/backend/src/main/java/com/pigma/harusari/statistics/query/dto/response/StatisticsDayResponse.java
+++ b/backend/src/main/java/com/pigma/harusari/statistics/query/dto/response/StatisticsDayResponse.java
@@ -2,8 +2,12 @@ package com.pigma.harusari.statistics.query.dto.response;
 
 import lombok.Builder;
 
+import java.time.LocalDate;
+
 @Builder
 public record StatisticsDayResponse(
+        String type,
+        LocalDate date,
         double achievementRate
 ) {
 }

--- a/backend/src/main/java/com/pigma/harusari/statistics/query/dto/response/StatisticsMonthResponse.java
+++ b/backend/src/main/java/com/pigma/harusari/statistics/query/dto/response/StatisticsMonthResponse.java
@@ -1,0 +1,13 @@
+package com.pigma.harusari.statistics.query.dto.response;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record StatisticsMonthResponse(
+        String type,
+        LocalDate date,
+        double achievementRate
+) {
+}

--- a/backend/src/main/java/com/pigma/harusari/statistics/query/dto/response/StatisticsMonthlyRateResponse.java
+++ b/backend/src/main/java/com/pigma/harusari/statistics/query/dto/response/StatisticsMonthlyRateResponse.java
@@ -1,0 +1,9 @@
+package com.pigma.harusari.statistics.query.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record StatisticsMonthlyRateResponse(
+        double achievementRate
+) {
+}

--- a/backend/src/main/java/com/pigma/harusari/statistics/query/exception/InvalidDateFormatException.java
+++ b/backend/src/main/java/com/pigma/harusari/statistics/query/exception/InvalidDateFormatException.java
@@ -1,0 +1,15 @@
+package com.pigma.harusari.statistics.query.exception;
+
+import lombok.Getter;
+
+@Getter
+public class InvalidDateFormatException extends RuntimeException {
+
+    private final StatisticsErrorCode errorCode;
+
+    public InvalidDateFormatException(StatisticsErrorCode errorCode) {
+        super(errorCode.getErrorMessage());
+        this.errorCode = errorCode;
+    }
+
+}

--- a/backend/src/main/java/com/pigma/harusari/statistics/query/exception/MissingDateException.java
+++ b/backend/src/main/java/com/pigma/harusari/statistics/query/exception/MissingDateException.java
@@ -1,0 +1,15 @@
+package com.pigma.harusari.statistics.query.exception;
+
+import lombok.Getter;
+
+@Getter
+public class MissingDateException extends RuntimeException {
+
+    private final StatisticsErrorCode errorCode;
+
+    public MissingDateException(StatisticsErrorCode errorCode) {
+        super(errorCode.getErrorMessage());
+        this.errorCode = errorCode;
+    }
+
+}

--- a/backend/src/main/java/com/pigma/harusari/statistics/query/exception/StatisticsErrorCode.java
+++ b/backend/src/main/java/com/pigma/harusari/statistics/query/exception/StatisticsErrorCode.java
@@ -1,0 +1,18 @@
+package com.pigma.harusari.statistics.query.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum StatisticsErrorCode {
+
+    INVALID_DATE_FORMAT("001", "날짜 형식이 올바르지 않습니다. yyyy-MM-dd 형식으로 입력해주세요.", HttpStatus.BAD_REQUEST),
+    MISSING_DATE("002", "날짜는 필수입니다.", HttpStatus.BAD_REQUEST);
+
+    private final String errorCode;
+    private final String errorMessage;
+    private final HttpStatus httpStatus;
+
+}

--- a/backend/src/main/java/com/pigma/harusari/statistics/query/exception/handler/StatisticsExceptionHandler.java
+++ b/backend/src/main/java/com/pigma/harusari/statistics/query/exception/handler/StatisticsExceptionHandler.java
@@ -1,0 +1,28 @@
+package com.pigma.harusari.statistics.query.exception.handler;
+
+import com.pigma.harusari.common.dto.ApiResponse;
+import com.pigma.harusari.statistics.query.exception.InvalidDateFormatException;
+import com.pigma.harusari.statistics.query.exception.MissingDateException;
+import com.pigma.harusari.statistics.query.exception.StatisticsErrorCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class StatisticsExceptionHandler {
+
+    @ExceptionHandler(InvalidDateFormatException.class)
+    public ResponseEntity<ApiResponse<Void>> handleInvalidDateFormatException(InvalidDateFormatException e) {
+        StatisticsErrorCode errorCode = e.getErrorCode();
+        ApiResponse<Void> response = ApiResponse.failure(errorCode.getErrorCode(), errorCode.getErrorMessage());
+        return new ResponseEntity<>(response, errorCode.getHttpStatus());
+    }
+
+    @ExceptionHandler(MissingDateException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMissingDateException(MissingDateException e) {
+        StatisticsErrorCode errorCode = e.getErrorCode();
+        ApiResponse<Void> response = ApiResponse.failure(errorCode.getErrorCode(), errorCode.getErrorMessage());
+        return new ResponseEntity<>(response, errorCode.getHttpStatus());
+    }
+
+}

--- a/backend/src/main/java/com/pigma/harusari/statistics/query/mapper/StatisticsMapper.java
+++ b/backend/src/main/java/com/pigma/harusari/statistics/query/mapper/StatisticsMapper.java
@@ -1,6 +1,6 @@
 package com.pigma.harusari.statistics.query.mapper;
 
-import com.pigma.harusari.statistics.query.dto.response.StatisticsDayResponse;
+import com.pigma.harusari.statistics.query.dto.response.StatisticsDailyRateResponse;
 import org.apache.ibatis.annotations.Mapper;
 
 import java.time.LocalDateTime;
@@ -8,6 +8,6 @@ import java.time.LocalDateTime;
 @Mapper
 public interface StatisticsMapper {
 
-    StatisticsDayResponse findStatisticsDaily(Long memberId, LocalDateTime startDateTime, LocalDateTime endDateTime);
+    StatisticsDailyRateResponse findStatisticsDailyRate(Long memberId, LocalDateTime startDateTime, LocalDateTime endDateTime);
 
 }

--- a/backend/src/main/java/com/pigma/harusari/statistics/query/mapper/StatisticsMapper.java
+++ b/backend/src/main/java/com/pigma/harusari/statistics/query/mapper/StatisticsMapper.java
@@ -1,6 +1,7 @@
 package com.pigma.harusari.statistics.query.mapper;
 
 import com.pigma.harusari.statistics.query.dto.response.StatisticsDailyRateResponse;
+import com.pigma.harusari.statistics.query.dto.response.StatisticsMonthlyRateResponse;
 import org.apache.ibatis.annotations.Mapper;
 
 import java.time.LocalDateTime;
@@ -9,5 +10,7 @@ import java.time.LocalDateTime;
 public interface StatisticsMapper {
 
     StatisticsDailyRateResponse findStatisticsDailyRate(Long memberId, LocalDateTime startDateTime, LocalDateTime endDateTime);
+
+    StatisticsMonthlyRateResponse findStatisticsMonthlyRate(Long memberId, LocalDateTime startDateTime, LocalDateTime endDateTime);
 
 }

--- a/backend/src/main/java/com/pigma/harusari/statistics/query/mapper/StatisticsMapper.java
+++ b/backend/src/main/java/com/pigma/harusari/statistics/query/mapper/StatisticsMapper.java
@@ -1,10 +1,12 @@
 package com.pigma.harusari.statistics.query.mapper;
 
+import com.pigma.harusari.statistics.query.dto.response.StatisticsCategoryRateResponse;
 import com.pigma.harusari.statistics.query.dto.response.StatisticsDailyRateResponse;
 import com.pigma.harusari.statistics.query.dto.response.StatisticsMonthlyRateResponse;
 import org.apache.ibatis.annotations.Mapper;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Mapper
 public interface StatisticsMapper {
@@ -12,5 +14,7 @@ public interface StatisticsMapper {
     StatisticsDailyRateResponse findStatisticsDailyRate(Long memberId, LocalDateTime startDateTime, LocalDateTime endDateTime);
 
     StatisticsMonthlyRateResponse findStatisticsMonthlyRate(Long memberId, LocalDateTime startDateTime, LocalDateTime endDateTime);
+
+    List<StatisticsCategoryRateResponse> findStatisticsCategoryRate(Long memberId);
 
 }

--- a/backend/src/main/java/com/pigma/harusari/statistics/query/mapper/StatisticsMapper.java
+++ b/backend/src/main/java/com/pigma/harusari/statistics/query/mapper/StatisticsMapper.java
@@ -1,0 +1,13 @@
+package com.pigma.harusari.statistics.query.mapper;
+
+import com.pigma.harusari.statistics.query.dto.response.StatisticsDayResponse;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.time.LocalDateTime;
+
+@Mapper
+public interface StatisticsMapper {
+
+    StatisticsDayResponse findStatisticsDaily(Long memberId, LocalDateTime startDateTime, LocalDateTime endDateTime);
+
+}

--- a/backend/src/main/java/com/pigma/harusari/statistics/query/service/StatisticsService.java
+++ b/backend/src/main/java/com/pigma/harusari/statistics/query/service/StatisticsService.java
@@ -1,5 +1,6 @@
 package com.pigma.harusari.statistics.query.service;
 
+import com.pigma.harusari.statistics.query.dto.response.StatisticsCategoryResponse;
 import com.pigma.harusari.statistics.query.dto.response.StatisticsDayResponse;
 import com.pigma.harusari.statistics.query.dto.response.StatisticsMonthResponse;
 
@@ -10,5 +11,7 @@ public interface StatisticsService {
     StatisticsDayResponse getStatisticsDaily(Long memberId, LocalDateTime startDateTime, LocalDateTime endDateTime);
 
     StatisticsMonthResponse getStatisticsMonthly(Long memberId, LocalDateTime startDateTime, LocalDateTime endDateTime);
+
+    StatisticsCategoryResponse getStatisticsCategory(Long memberId);
 
 }

--- a/backend/src/main/java/com/pigma/harusari/statistics/query/service/StatisticsService.java
+++ b/backend/src/main/java/com/pigma/harusari/statistics/query/service/StatisticsService.java
@@ -1,11 +1,14 @@
 package com.pigma.harusari.statistics.query.service;
 
 import com.pigma.harusari.statistics.query.dto.response.StatisticsDayResponse;
+import com.pigma.harusari.statistics.query.dto.response.StatisticsMonthResponse;
 
 import java.time.LocalDateTime;
 
 public interface StatisticsService {
 
     StatisticsDayResponse getStatisticsDaily(Long memberId, LocalDateTime startDateTime, LocalDateTime endDateTime);
+
+    StatisticsMonthResponse getStatisticsMonthly(Long memberId, LocalDateTime startDateTime, LocalDateTime endDateTime);
 
 }

--- a/backend/src/main/java/com/pigma/harusari/statistics/query/service/StatisticsService.java
+++ b/backend/src/main/java/com/pigma/harusari/statistics/query/service/StatisticsService.java
@@ -1,0 +1,11 @@
+package com.pigma.harusari.statistics.query.service;
+
+import com.pigma.harusari.statistics.query.dto.response.StatisticsDayResponse;
+
+import java.time.LocalDateTime;
+
+public interface StatisticsService {
+
+    StatisticsDayResponse getStatisticsDaily(Long memberId, LocalDateTime startDateTime, LocalDateTime endDateTime);
+
+}

--- a/backend/src/main/java/com/pigma/harusari/statistics/query/service/StatisticsServiceImpl.java
+++ b/backend/src/main/java/com/pigma/harusari/statistics/query/service/StatisticsServiceImpl.java
@@ -1,5 +1,7 @@
 package com.pigma.harusari.statistics.query.service;
 
+import com.pigma.harusari.statistics.common.StatisticsType;
+import com.pigma.harusari.statistics.query.dto.response.StatisticsDailyRateResponse;
 import com.pigma.harusari.statistics.query.dto.response.StatisticsDayResponse;
 import com.pigma.harusari.statistics.query.mapper.StatisticsMapper;
 import lombok.RequiredArgsConstructor;
@@ -19,15 +21,19 @@ public class StatisticsServiceImpl implements StatisticsService{
 
     @Override
     public StatisticsDayResponse getStatisticsDaily(Long memberId, LocalDateTime startDateTime, LocalDateTime endDateTime) {
-        StatisticsDayResponse statisticsDaily = statisticsMapper.findStatisticsDaily(memberId, startDateTime, endDateTime);
+        StatisticsDailyRateResponse dayRateResponse = statisticsMapper.findStatisticsDailyRate(memberId, startDateTime, endDateTime);
 
-        if (statisticsDaily == null) {
+        if (dayRateResponse == null) {
             return StatisticsDayResponse.builder()
                     .achievementRate(DEFAULT_ACHIEVEMENT_RATE)
                     .build();
         }
 
-        return statisticsDaily;
+        return StatisticsDayResponse.builder()
+                .type(StatisticsType.DAILY.name())
+                .date(startDateTime.toLocalDate())
+                .achievementRate(dayRateResponse.achievementRate())
+                .build();
     }
 
 }

--- a/backend/src/main/java/com/pigma/harusari/statistics/query/service/StatisticsServiceImpl.java
+++ b/backend/src/main/java/com/pigma/harusari/statistics/query/service/StatisticsServiceImpl.java
@@ -3,6 +3,8 @@ package com.pigma.harusari.statistics.query.service;
 import com.pigma.harusari.statistics.common.StatisticsType;
 import com.pigma.harusari.statistics.query.dto.response.StatisticsDailyRateResponse;
 import com.pigma.harusari.statistics.query.dto.response.StatisticsDayResponse;
+import com.pigma.harusari.statistics.query.dto.response.StatisticsMonthResponse;
+import com.pigma.harusari.statistics.query.dto.response.StatisticsMonthlyRateResponse;
 import com.pigma.harusari.statistics.query.mapper.StatisticsMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -33,6 +35,23 @@ public class StatisticsServiceImpl implements StatisticsService{
                 .type(StatisticsType.DAILY.name())
                 .date(startDateTime.toLocalDate())
                 .achievementRate(dayRateResponse.achievementRate())
+                .build();
+    }
+
+    @Override
+    public StatisticsMonthResponse getStatisticsMonthly(Long memberId, LocalDateTime startDateTime, LocalDateTime endDateTime) {
+        StatisticsMonthlyRateResponse monthlyRateResponse = statisticsMapper.findStatisticsMonthlyRate(memberId, startDateTime, endDateTime);
+
+        if (monthlyRateResponse == null) {
+            return StatisticsMonthResponse.builder()
+                    .achievementRate(DEFAULT_ACHIEVEMENT_RATE)
+                    .build();
+        }
+
+        return StatisticsMonthResponse.builder()
+                .type(StatisticsType.MONTHLY.name())
+                .date(startDateTime.toLocalDate())
+                .achievementRate(monthlyRateResponse.achievementRate())
                 .build();
     }
 

--- a/backend/src/main/java/com/pigma/harusari/statistics/query/service/StatisticsServiceImpl.java
+++ b/backend/src/main/java/com/pigma/harusari/statistics/query/service/StatisticsServiceImpl.java
@@ -1,0 +1,33 @@
+package com.pigma.harusari.statistics.query.service;
+
+import com.pigma.harusari.statistics.query.dto.response.StatisticsDayResponse;
+import com.pigma.harusari.statistics.query.mapper.StatisticsMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class StatisticsServiceImpl implements StatisticsService{
+
+    private static final double DEFAULT_ACHIEVEMENT_RATE = 0.0;
+
+    private final StatisticsMapper statisticsMapper;
+
+    @Override
+    public StatisticsDayResponse getStatisticsDaily(Long memberId, LocalDateTime startDateTime, LocalDateTime endDateTime) {
+        StatisticsDayResponse statisticsDaily = statisticsMapper.findStatisticsDaily(memberId, startDateTime, endDateTime);
+
+        if (statisticsDaily == null) {
+            return StatisticsDayResponse.builder()
+                    .achievementRate(DEFAULT_ACHIEVEMENT_RATE)
+                    .build();
+        }
+
+        return statisticsDaily;
+    }
+
+}

--- a/backend/src/main/java/com/pigma/harusari/statistics/query/service/StatisticsServiceImpl.java
+++ b/backend/src/main/java/com/pigma/harusari/statistics/query/service/StatisticsServiceImpl.java
@@ -1,16 +1,14 @@
 package com.pigma.harusari.statistics.query.service;
 
 import com.pigma.harusari.statistics.common.StatisticsType;
-import com.pigma.harusari.statistics.query.dto.response.StatisticsDailyRateResponse;
-import com.pigma.harusari.statistics.query.dto.response.StatisticsDayResponse;
-import com.pigma.harusari.statistics.query.dto.response.StatisticsMonthResponse;
-import com.pigma.harusari.statistics.query.dto.response.StatisticsMonthlyRateResponse;
+import com.pigma.harusari.statistics.query.dto.response.*;
 import com.pigma.harusari.statistics.query.mapper.StatisticsMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
@@ -52,6 +50,26 @@ public class StatisticsServiceImpl implements StatisticsService{
                 .type(StatisticsType.MONTHLY.name())
                 .date(startDateTime.toLocalDate())
                 .achievementRate(monthlyRateResponse.achievementRate())
+                .build();
+    }
+
+    @Override
+    public StatisticsCategoryResponse getStatisticsCategory(Long memberId) {
+        List<StatisticsCategoryRateResponse> statisticsCategoryRateList = statisticsMapper.findStatisticsCategoryRate(memberId);
+
+        if (statisticsCategoryRateList == null ) {
+            return StatisticsCategoryResponse.builder()
+                    .type(StatisticsType.CATEGORY.name())
+                    .categoryRates(List.of(StatisticsCategoryRateResponse.builder()
+                            .categoryName(null)
+                            .achievementRate(DEFAULT_ACHIEVEMENT_RATE)
+                            .build()))
+                    .build();
+        }
+
+        return StatisticsCategoryResponse.builder()
+                .type(StatisticsType.CATEGORY.name())
+                .categoryRates(statisticsCategoryRateList)
                 .build();
     }
 

--- a/backend/src/main/java/com/pigma/harusari/statistics/query/utils/StatisticsRequestParser.java
+++ b/backend/src/main/java/com/pigma/harusari/statistics/query/utils/StatisticsRequestParser.java
@@ -1,0 +1,25 @@
+package com.pigma.harusari.statistics.query.utils;
+
+import com.pigma.harusari.statistics.query.exception.InvalidDateFormatException;
+import com.pigma.harusari.statistics.query.exception.MissingDateException;
+import com.pigma.harusari.statistics.query.exception.StatisticsErrorCode;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+public class StatisticsRequestParser {
+
+    public static LocalDate parseDate(String date) {
+        if (date == null || date.isBlank()) {
+            throw new MissingDateException(StatisticsErrorCode.MISSING_DATE);
+        }
+
+        try {
+            return LocalDate.parse(date, DateTimeFormatter.ISO_DATE);
+        } catch (DateTimeParseException e) {
+            throw new InvalidDateFormatException(StatisticsErrorCode.INVALID_DATE_FORMAT);
+        }
+    }
+
+}

--- a/backend/src/main/resources/mappers/statistics/StatisticsMapper.xml
+++ b/backend/src/main/resources/mappers/statistics/StatisticsMapper.xml
@@ -16,4 +16,19 @@
         AND s.schedule_deadline <![CDATA[ >= ]]> #{startDateTime}
         AND s.schedule_deadline <![CDATA[ < ]]> #{endDateTime}
     </select>
+
+    <select id="findStatisticsMonthlyRate" resultType="com.pigma.harusari.statistics.query.dto.response.StatisticsMonthlyRateResponse">
+        SELECT
+            ROUND(
+                CASE
+                    WHEN COUNT(*) = 0 THEN 0
+                    ELSE SUM(CASE WHEN s.completion_status = 1 THEN 1 ELSE 0 END) * 100.0 / COUNT(*)
+                END
+            , 2) AS achievementRate
+        FROM schedule s
+        JOIN category c ON s.category_id = c.category_id
+        WHERE c.member_uid = #{memberId}
+        AND s.schedule_deadline <![CDATA[ >= ]]> #{startDateTime}
+        AND s.schedule_deadline <![CDATA[ < ]]> #{endDateTime}
+    </select>
 </mapper>

--- a/backend/src/main/resources/mappers/statistics/StatisticsMapper.xml
+++ b/backend/src/main/resources/mappers/statistics/StatisticsMapper.xml
@@ -31,4 +31,19 @@
         AND s.schedule_deadline <![CDATA[ >= ]]> #{startDateTime}
         AND s.schedule_deadline <![CDATA[ < ]]> #{endDateTime}
     </select>
+
+    <select id="findStatisticsCategoryRate" resultType="com.pigma.harusari.statistics.query.dto.response.StatisticsCategoryRateResponse">
+        SELECT
+            c.name AS categoryName,
+            ROUND(
+                CASE
+                    WHEN COUNT(*) = 0 THEN 0
+                    ELSE SUM(CASE WHEN s.completion_status = 1 THEN 1 ELSE 0 END) * 100.0 / COUNT(*)
+                END
+            , 2) AS achievementRate
+        FROM schedule s
+        JOIN category c ON s.category_id = c.category_id
+        WHERE c.member_uid = #{memberId}
+        GROUP BY c.category_id, c.category_name
+    </select>
 </mapper>

--- a/backend/src/main/resources/mappers/statistics/StatisticsMapper.xml
+++ b/backend/src/main/resources/mappers/statistics/StatisticsMapper.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.pigma.harusari.statistics.query.mapper.StatisticsMapper">
+    <select id="findStatisticsDailyRate" resultType="com.pigma.harusari.statistics.query.dto.response.StatisticsRateResponse">
+        SELECT
+            ROUND(
+                CASE
+                    WHEN COUNT(*) = 0 THEN 0
+                    ELSE SUM(CASE WHEN s.completion_status = 1 THEN 1 ELSE 0 END) * 100.0 / COUNT(*)
+                END
+            , 2) AS achievementRate
+        FROM schedule s
+        JOIN category c ON s.category_id = c.category_id
+        WHERE c.member_uid = #{memberId}
+        AND s.schedule_deadline <![CDATA[ >= ]]> #{startDateTime}
+        AND s.schedule_deadline <![CDATA[ < ]]> #{endDateTime}
+    </select>
+</mapper>

--- a/backend/src/main/resources/mappers/statistics/StatisticsMapper.xml
+++ b/backend/src/main/resources/mappers/statistics/StatisticsMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="com.pigma.harusari.statistics.query.mapper.StatisticsMapper">
-    <select id="findStatisticsDailyRate" resultType="com.pigma.harusari.statistics.query.dto.response.StatisticsRateResponse">
+    <select id="findStatisticsDailyRate" resultType="com.pigma.harusari.statistics.query.dto.response.StatisticsDailyRateResponse">
         SELECT
             ROUND(
                 CASE

--- a/backend/src/test/java/com/pigma/harusari/statistics/query/controller/StatisticsControllerTest.java
+++ b/backend/src/test/java/com/pigma/harusari/statistics/query/controller/StatisticsControllerTest.java
@@ -1,5 +1,6 @@
 package com.pigma.harusari.statistics.query.controller;
 
+import com.pigma.harusari.statistics.common.StatisticsType;
 import com.pigma.harusari.statistics.query.dto.response.StatisticsDayResponse;
 import com.pigma.harusari.statistics.query.exception.StatisticsErrorCode;
 import com.pigma.harusari.statistics.query.service.StatisticsService;
@@ -43,6 +44,8 @@ class StatisticsControllerTest {
     @BeforeEach
     void setUp() {
         statisticsDayResponse = StatisticsDayResponse.builder()
+                .type(StatisticsType.DAILY.name())
+                .date(LocalDate.now())
                 .achievementRate(55.25)
                 .build();
     }
@@ -65,7 +68,10 @@ class StatisticsControllerTest {
                 ).andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.achievementRate").exists())
+                .andExpect(jsonPath("$.data.type").exists())
+                .andExpect(jsonPath("$.data.type").value(StatisticsType.DAILY.name()))
+                .andExpect(jsonPath("$.data.date").exists())
+                .andExpect(jsonPath("$.data.date").value(date.toString()))
                 .andExpect(jsonPath("$.data.achievementRate").value(statisticsDayResponse.achievementRate()))
                 .andExpect(jsonPath("$.timestamp").exists())
                 .andExpect(jsonPath("$.errorCode").doesNotExist())

--- a/backend/src/test/java/com/pigma/harusari/statistics/query/controller/StatisticsControllerTest.java
+++ b/backend/src/test/java/com/pigma/harusari/statistics/query/controller/StatisticsControllerTest.java
@@ -1,0 +1,115 @@
+package com.pigma.harusari.statistics.query.controller;
+
+import com.pigma.harusari.statistics.query.dto.response.StatisticsDayResponse;
+import com.pigma.harusari.statistics.query.exception.StatisticsErrorCode;
+import com.pigma.harusari.statistics.query.service.StatisticsService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(StatisticsController.class)
+@ImportAutoConfiguration(exclude = SecurityAutoConfiguration.class)
+@DisplayName("[통계 - controller] StatisticsController 테스트")
+class StatisticsControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    StatisticsService statisticsService;
+
+    StatisticsDayResponse statisticsDayResponse;
+
+    @BeforeEach
+    void setUp() {
+        statisticsDayResponse = StatisticsDayResponse.builder()
+                .achievementRate(55.25)
+                .build();
+    }
+
+    @Test
+    @DisplayName("[일일 달성률] 통계 조회 테스트")
+    void getStatisticsDaily() throws Exception {
+        Long memberId = 1L;
+
+        LocalDate date = LocalDate.now();
+        LocalDateTime startDateTime = date.atStartOfDay();
+        LocalDateTime endDateTime = date.plusDays(1).atStartOfDay();
+
+        when(statisticsService.getStatisticsDaily(memberId, startDateTime, endDateTime)).thenReturn(statisticsDayResponse);
+
+        mockMvc.perform(get("/api/v1/statistics/daily")
+                        .param("date", date.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                ).andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.achievementRate").exists())
+                .andExpect(jsonPath("$.data.achievementRate").value(statisticsDayResponse.achievementRate()))
+                .andExpect(jsonPath("$.timestamp").exists())
+                .andExpect(jsonPath("$.errorCode").doesNotExist())
+                .andExpect(jsonPath("$.message").doesNotExist())
+                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "\t", "\n"})
+    @DisplayName("[일일 달성률] 통계 조회 시 날짜 값이 경우 예외가 발생하는 테스트")
+    void getStatisticsDailyDateMissingDateException(String condition) throws Exception {
+        mockMvc.perform(get("/api/v1/statistics/daily")
+                        .param("date", condition)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                ).andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.timestamp").exists())
+                .andExpect(jsonPath("$.errorCode").exists())
+                .andExpect(jsonPath("$.errorCode").value(StatisticsErrorCode.MISSING_DATE.getErrorCode()))
+                .andExpect(jsonPath("$.message").exists())
+                .andExpect(jsonPath("$.message").value(StatisticsErrorCode.MISSING_DATE.getErrorMessage()))
+                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE));
+    }
+
+    @ParameterizedTest
+    @CsvSource({"2025.01.01", "2025-01-01 15:30:15"})
+    @DisplayName("[일일 달성률] 통계 조회 시 날짜 형식이 맞지 않는 경우 예외가 발생하는 테스트")
+    void getStatisticsDailyInvalidDateFormatException(String condition) throws Exception {
+        mockMvc.perform(get("/api/v1/statistics/daily")
+                        .param("date", condition)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                ).andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.timestamp").exists())
+                .andExpect(jsonPath("$.errorCode").exists())
+                .andExpect(jsonPath("$.errorCode").value(StatisticsErrorCode.INVALID_DATE_FORMAT.getErrorCode()))
+                .andExpect(jsonPath("$.message").exists())
+                .andExpect(jsonPath("$.message").value(StatisticsErrorCode.INVALID_DATE_FORMAT.getErrorMessage()))
+                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE));
+    }
+
+}

--- a/backend/src/test/java/com/pigma/harusari/statistics/query/controller/StatisticsControllerTest.java
+++ b/backend/src/test/java/com/pigma/harusari/statistics/query/controller/StatisticsControllerTest.java
@@ -2,8 +2,10 @@ package com.pigma.harusari.statistics.query.controller;
 
 import com.pigma.harusari.statistics.common.StatisticsType;
 import com.pigma.harusari.statistics.query.dto.response.StatisticsDayResponse;
+import com.pigma.harusari.statistics.query.dto.response.StatisticsMonthResponse;
 import com.pigma.harusari.statistics.query.exception.StatisticsErrorCode;
 import com.pigma.harusari.statistics.query.service.StatisticsService;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,6 +30,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+@Slf4j
 @WebMvcTest(StatisticsController.class)
 @ImportAutoConfiguration(exclude = SecurityAutoConfiguration.class)
 @DisplayName("[통계 - controller] StatisticsController 테스트")
@@ -40,6 +43,7 @@ class StatisticsControllerTest {
     StatisticsService statisticsService;
 
     StatisticsDayResponse statisticsDayResponse;
+    StatisticsMonthResponse statisticsMonthResponse;
 
     @BeforeEach
     void setUp() {
@@ -48,11 +52,18 @@ class StatisticsControllerTest {
                 .date(LocalDate.now())
                 .achievementRate(55.25)
                 .build();
+
+        statisticsMonthResponse = StatisticsMonthResponse.builder()
+                .type(StatisticsType.MONTHLY.name())
+                .date(LocalDate.now())
+                .achievementRate(75.00)
+                .build();
     }
 
+    /* 일일 달성률 */
     @Test
     @DisplayName("[일일 달성률] 통계 조회 테스트")
-    void getStatisticsDaily() throws Exception {
+    void testGetStatisticsDaily() throws Exception {
         Long memberId = 1L;
 
         LocalDate date = LocalDate.now();
@@ -83,7 +94,7 @@ class StatisticsControllerTest {
     @NullAndEmptySource
     @ValueSource(strings = {" ", "\t", "\n"})
     @DisplayName("[일일 달성률] 통계 조회 시 날짜 값이 경우 예외가 발생하는 테스트")
-    void getStatisticsDailyDateMissingDateException(String condition) throws Exception {
+    void testGetStatisticsDailyDateMissingDateException(String condition) throws Exception {
         mockMvc.perform(get("/api/v1/statistics/daily")
                         .param("date", condition)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -102,8 +113,80 @@ class StatisticsControllerTest {
     @ParameterizedTest
     @CsvSource({"2025.01.01", "2025-01-01 15:30:15"})
     @DisplayName("[일일 달성률] 통계 조회 시 날짜 형식이 맞지 않는 경우 예외가 발생하는 테스트")
-    void getStatisticsDailyInvalidDateFormatException(String condition) throws Exception {
+    void testGetStatisticsDailyInvalidDateFormatException(String condition) throws Exception {
         mockMvc.perform(get("/api/v1/statistics/daily")
+                        .param("date", condition)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                ).andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.timestamp").exists())
+                .andExpect(jsonPath("$.errorCode").exists())
+                .andExpect(jsonPath("$.errorCode").value(StatisticsErrorCode.INVALID_DATE_FORMAT.getErrorCode()))
+                .andExpect(jsonPath("$.message").exists())
+                .andExpect(jsonPath("$.message").value(StatisticsErrorCode.INVALID_DATE_FORMAT.getErrorMessage()))
+                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE));
+    }
+
+    /* 월별 달성률 */
+    @Test
+    @DisplayName("[월별 달성률] 통계 조회 테스트")
+    void testGetStatisticsMonthly() throws Exception {
+        Long memberId = 1L;
+
+        LocalDate date = LocalDate.now();
+        LocalDateTime startDateTime = date.withDayOfMonth(1).atStartOfDay();
+        LocalDateTime endDateTime = date.plusMonths(1).withDayOfMonth(1).atStartOfDay();
+
+        log.info("startDateTime = {}", startDateTime);
+        log.info("endDateTime = {}", endDateTime);
+
+        when(statisticsService.getStatisticsMonthly(memberId, startDateTime, endDateTime)).thenReturn(statisticsMonthResponse);
+
+        mockMvc.perform(get("/api/v1/statistics/monthly")
+                        .param("date", date.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                ).andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.type").exists())
+                .andExpect(jsonPath("$.data.type").value(StatisticsType.MONTHLY.name()))
+                .andExpect(jsonPath("$.data.date").exists())
+                .andExpect(jsonPath("$.data.date").value(date.toString()))
+                .andExpect(jsonPath("$.data.achievementRate").value(statisticsMonthResponse.achievementRate()))
+                .andExpect(jsonPath("$.timestamp").exists())
+                .andExpect(jsonPath("$.errorCode").doesNotExist())
+                .andExpect(jsonPath("$.message").doesNotExist())
+                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "\t", "\n"})
+    @DisplayName("[월별 달성률] 통계 조회 시 날짜 값이 경우 예외가 발생하는 테스트")
+    void testGetStatisticsMonthlyDateMissingDateException(String condition) throws Exception {
+        mockMvc.perform(get("/api/v1/statistics/monthly")
+                        .param("date", condition)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                ).andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.timestamp").exists())
+                .andExpect(jsonPath("$.errorCode").exists())
+                .andExpect(jsonPath("$.errorCode").value(StatisticsErrorCode.MISSING_DATE.getErrorCode()))
+                .andExpect(jsonPath("$.message").exists())
+                .andExpect(jsonPath("$.message").value(StatisticsErrorCode.MISSING_DATE.getErrorMessage()))
+                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE));
+    }
+
+    @ParameterizedTest
+    @CsvSource({"2025.02.22", "2025-10-01 23:44:11"})
+    @DisplayName("[월별 달성률] 통계 조회 시 날짜 형식이 맞지 않는 경우 예외가 발생하는 테스트")
+    void testGetStatisticsMonthlyInvalidDateFormatException(String condition) throws Exception {
+        mockMvc.perform(get("/api/v1/statistics/monthly")
                         .param("date", condition)
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)

--- a/backend/src/test/java/com/pigma/harusari/statistics/query/service/StatisticsServiceImplTest.java
+++ b/backend/src/test/java/com/pigma/harusari/statistics/query/service/StatisticsServiceImplTest.java
@@ -1,5 +1,7 @@
 package com.pigma.harusari.statistics.query.service;
 
+import com.pigma.harusari.statistics.common.StatisticsType;
+import com.pigma.harusari.statistics.query.dto.response.StatisticsDailyRateResponse;
 import com.pigma.harusari.statistics.query.dto.response.StatisticsDayResponse;
 import com.pigma.harusari.statistics.query.mapper.StatisticsMapper;
 import lombok.extern.slf4j.Slf4j;
@@ -30,10 +32,18 @@ class StatisticsServiceImplTest {
 
     StatisticsDayResponse statisticsDayResponse;
 
+    StatisticsDailyRateResponse statisticsDailyRateResponse;
+
     @BeforeEach
     void setUp() {
-        statisticsDayResponse = StatisticsDayResponse.builder()
+        statisticsDailyRateResponse = StatisticsDailyRateResponse.builder()
                 .achievementRate(55.25)
+                .build();
+
+        statisticsDayResponse = StatisticsDayResponse.builder()
+                .type(StatisticsType.DAILY.name())
+                .date(LocalDate.now())
+                .achievementRate(statisticsDailyRateResponse.achievementRate())
                 .build();
     }
 
@@ -45,13 +55,15 @@ class StatisticsServiceImplTest {
         LocalDateTime startDateTime = date.atStartOfDay();
         LocalDateTime endDateTime = date.plusDays(1).atStartOfDay();
 
-        when(statisticsMapper.findStatisticsDaily(memberId, startDateTime, endDateTime)).thenReturn(statisticsDayResponse);
+        when(statisticsMapper.findStatisticsDailyRate(memberId, startDateTime, endDateTime)).thenReturn(statisticsDailyRateResponse);
 
         StatisticsDayResponse statisticsDaily = statisticsServiceImpl.getStatisticsDaily(memberId, startDateTime, endDateTime);
 
         log.info("statisticsDaily = {}", statisticsDaily);
 
         assertThat(statisticsDaily).isEqualTo(statisticsDayResponse);
+        assertThat(statisticsDaily.type()).isEqualTo(statisticsDayResponse.type());
+        assertThat(statisticsDaily.date()).isEqualTo(statisticsDayResponse.date());
         assertThat(statisticsDaily.achievementRate()).isEqualTo(statisticsDayResponse.achievementRate());
     }
 
@@ -63,7 +75,7 @@ class StatisticsServiceImplTest {
         LocalDateTime startDateTime = date.atStartOfDay();
         LocalDateTime endDateTime = date.plusDays(1).atStartOfDay();
 
-        when(statisticsMapper.findStatisticsDaily(memberId, startDateTime, endDateTime)).thenReturn(null);
+        when(statisticsMapper.findStatisticsDailyRate(memberId, startDateTime, endDateTime)).thenReturn(null);
 
         StatisticsDayResponse statisticsDaily = statisticsServiceImpl.getStatisticsDaily(memberId, startDateTime, endDateTime);
 

--- a/backend/src/test/java/com/pigma/harusari/statistics/query/service/StatisticsServiceImplTest.java
+++ b/backend/src/test/java/com/pigma/harusari/statistics/query/service/StatisticsServiceImplTest.java
@@ -1,0 +1,76 @@
+package com.pigma.harusari.statistics.query.service;
+
+import com.pigma.harusari.statistics.query.dto.response.StatisticsDayResponse;
+import com.pigma.harusari.statistics.query.mapper.StatisticsMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@Slf4j
+@ExtendWith(MockitoExtension.class)
+@DisplayName("[통계 - service] StatisticsServiceImpl 테스트")
+class StatisticsServiceImplTest {
+
+    @InjectMocks
+    StatisticsServiceImpl statisticsServiceImpl;
+
+    @Mock
+    StatisticsMapper statisticsMapper;
+
+    StatisticsDayResponse statisticsDayResponse;
+
+    @BeforeEach
+    void setUp() {
+        statisticsDayResponse = StatisticsDayResponse.builder()
+                .achievementRate(55.25)
+                .build();
+    }
+
+    @Test
+    @DisplayName("[일일 달성률] 완료한 개수와 미완료한 개수를 구하는 테스트")
+    void testGetStatisticsDaily() {
+        Long memberId = 1L;
+        LocalDate date = LocalDate.now();
+        LocalDateTime startDateTime = date.atStartOfDay();
+        LocalDateTime endDateTime = date.plusDays(1).atStartOfDay();
+
+        when(statisticsMapper.findStatisticsDaily(memberId, startDateTime, endDateTime)).thenReturn(statisticsDayResponse);
+
+        StatisticsDayResponse statisticsDaily = statisticsServiceImpl.getStatisticsDaily(memberId, startDateTime, endDateTime);
+
+        log.info("statisticsDaily = {}", statisticsDaily);
+
+        assertThat(statisticsDaily).isEqualTo(statisticsDayResponse);
+        assertThat(statisticsDaily.achievementRate()).isEqualTo(statisticsDayResponse.achievementRate());
+    }
+
+    @Test
+    @DisplayName("[일일 달성률] 할 일을 작성하지 않는 경우 완료한 개수와 미완료한 개수를 구하는 테스트")
+    void testDailyStatisticsWithEmptyTaskList() {
+        Long memberId = 1L;
+        LocalDate date = LocalDate.now();
+        LocalDateTime startDateTime = date.atStartOfDay();
+        LocalDateTime endDateTime = date.plusDays(1).atStartOfDay();
+
+        when(statisticsMapper.findStatisticsDaily(memberId, startDateTime, endDateTime)).thenReturn(null);
+
+        StatisticsDayResponse statisticsDaily = statisticsServiceImpl.getStatisticsDaily(memberId, startDateTime, endDateTime);
+
+        log.info("statisticsDaily = {}", statisticsDaily);
+
+        assertThat(statisticsDaily).isNotNull();
+        assertThat(statisticsDaily.achievementRate()).isEqualTo(0.0);
+    }
+
+}

--- a/backend/src/test/java/com/pigma/harusari/statistics/query/utils/StatisticsRequestParserTest.java
+++ b/backend/src/test/java/com/pigma/harusari/statistics/query/utils/StatisticsRequestParserTest.java
@@ -1,0 +1,36 @@
+package com.pigma.harusari.statistics.query.utils;
+
+import com.pigma.harusari.statistics.query.exception.InvalidDateFormatException;
+import com.pigma.harusari.statistics.query.exception.MissingDateException;
+import com.pigma.harusari.statistics.query.exception.StatisticsErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("[통계 - utils] StatisticsRequestParser 테스트")
+class StatisticsRequestParserTest {
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "\t", "\n"})
+    @DisplayName("[예외] 날짜 값이 경우 예외가 발생하는 테스트")
+    void parseDateMissingDateException(String condition) {
+        assertThatThrownBy(() -> StatisticsRequestParser.parseDate(condition))
+                .isInstanceOf(MissingDateException.class)
+                .hasMessage(StatisticsErrorCode.MISSING_DATE.getErrorMessage());
+    }
+
+    @ParameterizedTest
+    @CsvSource({"2025.01.01", "2025-01-01 15:30:15"})
+    @DisplayName("[예외] 날짜 형식에 맞지 않은 경우 예외가 발생하는 테스트")
+    void parseDateInvalidDateFormatException(String condition) {
+        assertThatThrownBy(() -> StatisticsRequestParser.parseDate(condition))
+                .isInstanceOf(InvalidDateFormatException.class)
+                .hasMessage(StatisticsErrorCode.INVALID_DATE_FORMAT.getErrorMessage());
+    }
+
+}


### PR DESCRIPTION
Closes #14

## 🔥 작업 내용  
- 일일 통계 API (`/statistics/daily`) 구현
- 사용자의 특정 날짜에 완료된 일정과 미완료 일정 개수를 계산
- 날짜 파라미터를 기준으로 하루 범위(00:00 ~ 23:59:59) 조회
- 결과가 없는 경우에도 기본값(0.0)으로 응답
- 월별 통계 API (`/statistics/monthly`) 구현
- 해당 월의 전체 일정 개수, 완료 일정 개수, 미완료 일정 개수 조회
- 달성률(%)을 계산하여 소수점 2자리까지 반환
- 카테고리별 통계 API (`/statistics/category`) 구현
- 회원이 가진 카테고리별로 완료율(%) 계산
- 동일한 카테고리 이름이 여러 개 존재해도 구분되도록 category_id 기준으로 집계
- 카테고리별 응답을 리스트로 묶어 반환하는 응답 DTO 설계
- 통계 전용 DTO 설계 및 MyBatis Mapper 구성
- `StatisticsDayResponse`, `StatisticsMonthResponse`, `StatisticsCategoryRateResponse` 등 응답용 DTO 생성
- 각 통계에 필요한 쿼리 작성 및 Mapper XML 구성
- 통계 Mapper 단위 테스트 코드 작성
- Controller, Service 구조 분리 및 예외 처리 설계
- API 요청 파라미터 유효성 검증
- 통계 결과가 없을 경우에도 예외가 아닌 정상 응답 처리
- GitHub Actions 워크플로우에 SERVER_PORT 환경 변수 추가

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [x] 코드 리뷰 반영 완료

## ✨ 관련 이슈
- #14 
