### PR TITLE
refactor: 통계 컨트롤러 내 상수명과 에러 코드 리팩토링

### DIFF
--- a/backend/src/main/java/com/pigma/harusari/statistics/query/controller/StatisticsController.java
+++ b/backend/src/main/java/com/pigma/harusari/statistics/query/controller/StatisticsController.java
@@ -20,7 +20,9 @@ import java.time.LocalDateTime;
 @RequiredArgsConstructor
 public class StatisticsController {
 
-    private static final long ONE_DAY = 1L;
+    private static final long STATISTICS_DAY_RANGE = 1L;
+    private static final long STATISTICS_MONTH_RANGE = 1L;
+    private static final int FIRST_DAY_OF_MONTH = 1;
 
     private final StatisticsService statisticsService;
 
@@ -33,7 +35,7 @@ public class StatisticsController {
         Long memberId = 1L; // 스프링 시큐리티 구현 완료되면 변경할 예정
 
         LocalDateTime startDateTime = parseDate.atStartOfDay();
-        LocalDateTime endDateTime = parseDate.plusDays(ONE_DAY).atStartOfDay();
+        LocalDateTime endDateTime = parseDate.plusDays(STATISTICS_DAY_RANGE).atStartOfDay();
 
         StatisticsDayResponse statisticsDaily = statisticsService.getStatisticsDaily(memberId, startDateTime, endDateTime);
 
@@ -50,8 +52,8 @@ public class StatisticsController {
 
         Long memberId = 1L; // 스프링 시큐리티 구현 완료되면 변경할 예정
 
-        LocalDateTime startDateTime = parseDate.withDayOfMonth(1).atStartOfDay();
-        LocalDateTime endDateTime = parseDate.plusMonths(1).withDayOfMonth(1).atStartOfDay();
+        LocalDateTime startDateTime = parseDate.withDayOfMonth(FIRST_DAY_OF_MONTH).atStartOfDay();
+        LocalDateTime endDateTime = parseDate.plusMonths(STATISTICS_MONTH_RANGE).withDayOfMonth(FIRST_DAY_OF_MONTH).atStartOfDay();
 
         StatisticsMonthResponse statisticsMonthly = statisticsService.getStatisticsMonthly(memberId, startDateTime, endDateTime);
 

--- a/backend/src/main/java/com/pigma/harusari/statistics/query/exception/StatisticsErrorCode.java
+++ b/backend/src/main/java/com/pigma/harusari/statistics/query/exception/StatisticsErrorCode.java
@@ -8,8 +8,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum StatisticsErrorCode {
 
-    INVALID_DATE_FORMAT("001", "날짜 형식이 올바르지 않습니다. yyyy-MM-dd 형식으로 입력해주세요.", HttpStatus.BAD_REQUEST),
-    MISSING_DATE("002", "날짜는 필수입니다.", HttpStatus.BAD_REQUEST);
+    INVALID_DATE_FORMAT("50001", "날짜 형식이 올바르지 않습니다. yyyy-MM-dd 형식으로 입력해주세요.", HttpStatus.BAD_REQUEST),
+    MISSING_DATE("50002", "날짜는 필수입니다.", HttpStatus.BAD_REQUEST);
 
     private final String errorCode;
     private final String errorMessage;


### PR DESCRIPTION
Closes #20 #22 

## 🔥 작업 내용  
- `ONE_DAY`, `ONE_MONTH` → `STATISTICS_DAY_RANGE`, `STATISTICS_MONTH_RANGE`로 변경
-  `withDayOfMonth(1)`의 `1`을 `FIRST_DAY_OF_MONTH` 상수로 추출
- `INVALID_DATE_FORMAT` 에러 코드를 001 → 50001 로 변경
-  `MISSING_DATE` 에러 코드를 002 → 50002 로 변경

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [x] 코드 리뷰 반영 완료

## ✨ 관련 이슈
- #20 
- #22 
