### PR TITLE
fix: main.css import 삭제

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,5 +1,3 @@
-import './assets/main.css'
-
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 


### PR DESCRIPTION
Closes #38 

## 🔥 작업 내용  
- main.js에서 import './assets/main.css' 삭제

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [x] 코드 리뷰 반영 완료

## ✨ 관련 이슈
- #38 