### PR TITLE
fix: 통계 쿼리에서 잘못된 컬럼명 수정 (c.name → c.category_name)

### DIFF
--- a/backend/src/main/resources/mappers/statistics/StatisticsMapper.xml
+++ b/backend/src/main/resources/mappers/statistics/StatisticsMapper.xml
@@ -34,7 +34,7 @@
 
     <select id="findStatisticsCategoryRate" resultType="com.pigma.harusari.statistics.query.dto.response.StatisticsCategoryRateResponse">
         SELECT
-            c.name AS categoryName,
+            c.category_name AS categoryName,
             ROUND(
                 CASE
                     WHEN COUNT(*) = 0 THEN 0


### PR DESCRIPTION
Closes #40 

## 🔥 작업 내용  
- StatisticsMapper.xml에서 c.name → c.category_name으로 컬럼명 수정

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [ ] 테스트 정상 동작 확인
- [ ] 코드 리뷰 반영 완료

## ✨ 관련 이슈
- #40 
