### PR TITLE
feat: CustomUserDetails 구현 및 Spring Security 인증 구조 개선

### DIFF
--- a/backend/src/main/java/com/pigma/harusari/alarm/command/controller/AlarmCommandController.java
+++ b/backend/src/main/java/com/pigma/harusari/alarm/command/controller/AlarmCommandController.java
@@ -1,11 +1,11 @@
 package com.pigma.harusari.alarm.command.controller;
 
 import com.pigma.harusari.alarm.command.service.AlarmCommandServiceImpl;
+import com.pigma.harusari.common.auth.model.CustomUserDetails;
 import com.pigma.harusari.common.dto.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,7 +18,9 @@ public class AlarmCommandController {
     private final AlarmCommandServiceImpl alarmCommandService;
 
     @PutMapping("/alarms/read-all")
-    public ResponseEntity<ApiResponse<Void>> markAllAsRead(@AuthenticationPrincipal User userDetails) {
+    public ResponseEntity<ApiResponse<Void>> markAllAsRead(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
         Long memberId = Long.parseLong(userDetails.getUsername());
         alarmCommandService.markAllAsRead(memberId);
         return ResponseEntity.ok(ApiResponse.success(null));

--- a/backend/src/main/java/com/pigma/harusari/alarm/query/controller/AlarmQueryController.java
+++ b/backend/src/main/java/com/pigma/harusari/alarm/query/controller/AlarmQueryController.java
@@ -2,11 +2,11 @@ package com.pigma.harusari.alarm.query.controller;
 
 import com.pigma.harusari.alarm.query.dto.AlarmResponseDto;
 import com.pigma.harusari.alarm.query.service.AlarmQueryService;
+import com.pigma.harusari.common.auth.model.CustomUserDetails;
 import com.pigma.harusari.common.dto.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,7 +21,9 @@ public class AlarmQueryController {
     private final AlarmQueryService alarmQueryService;
 
     @GetMapping("/unread")
-    public ResponseEntity<ApiResponse<List<AlarmResponseDto>>> getUnreadAlarms(@AuthenticationPrincipal User userDetails) {
+    public ResponseEntity<ApiResponse<List<AlarmResponseDto>>> getUnreadAlarms(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
         Long memberId = Long.parseLong(userDetails.getUsername());
 
         List<AlarmResponseDto> alarms = alarmQueryService.getUnreadAlarms(memberId);

--- a/backend/src/main/java/com/pigma/harusari/alarm/sse/SseController.java
+++ b/backend/src/main/java/com/pigma/harusari/alarm/sse/SseController.java
@@ -1,9 +1,9 @@
 package com.pigma.harusari.alarm.sse;
 
+import com.pigma.harusari.common.auth.model.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -15,7 +15,9 @@ public class SseController {
     private final SseService sseService;
 
     @GetMapping(value = "/alarm", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter subscribe(@AuthenticationPrincipal User userDetails) {
+    public SseEmitter subscribe(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
         // userDetails에서 memberId(즉 userId) 추출
         Long memberId = Long.parseLong(userDetails.getUsername());
         return sseService.subscribe(memberId);

--- a/backend/src/main/java/com/pigma/harusari/common/auth/model/CustomUserDetails.java
+++ b/backend/src/main/java/com/pigma/harusari/common/auth/model/CustomUserDetails.java
@@ -1,0 +1,60 @@
+package com.pigma.harusari.common.auth.model;
+
+import com.pigma.harusari.user.command.entity.Member;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Getter
+public class CustomUserDetails implements UserDetails {
+
+    private final Long memberId;
+    private final String email;
+    private final String password;
+
+    public CustomUserDetails(Member member) {
+        this.memberId = member.getMemberId();
+        this.email = member.getEmail();
+        this.password = member.getPassword();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singleton(() -> "ROLE_USER");
+    }
+
+    @Override
+    public String getPassword() {
+        return this.password;
+    }
+
+    // `@AuthenticationPrincipal`에서 사용할 식별자
+    @Override
+    public String getUsername() {
+        return String.valueOf(this.memberId);  // DB ID로 식별
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+}

--- a/backend/src/main/java/com/pigma/harusari/common/auth/service/CustomUserDetailsService.java
+++ b/backend/src/main/java/com/pigma/harusari/common/auth/service/CustomUserDetailsService.java
@@ -2,16 +2,14 @@ package com.pigma.harusari.common.auth.service;
 
 import com.pigma.harusari.common.auth.exception.AuthErrorCode;
 import com.pigma.harusari.common.auth.exception.LogInMemberNotFoundException;
+import com.pigma.harusari.common.auth.model.CustomUserDetails;
 import com.pigma.harusari.user.command.entity.Member;
 import com.pigma.harusari.user.command.repository.UserCommandRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
-
-import java.util.Collections;
 
 @Service
 @RequiredArgsConstructor
@@ -24,11 +22,6 @@ public class CustomUserDetailsService implements UserDetailsService {
         Member member = userCommandRepository.findById(Long.parseLong(userId))
                 .orElseThrow(() -> new LogInMemberNotFoundException(AuthErrorCode.LOGIN_MEMBER_NOT_FOUND));
 
-        return new org.springframework.security.core.userdetails.User(
-                String.valueOf(member.getMemberId()),
-                member.getPassword(),
-                Collections.singleton(new SimpleGrantedAuthority("ROLE_USER"))
-        );
+        return new CustomUserDetails(member);
     }
-
 }

--- a/backend/src/main/java/com/pigma/harusari/common/config/SecurityConfig.java
+++ b/backend/src/main/java/com/pigma/harusari/common/config/SecurityConfig.java
@@ -8,6 +8,8 @@ import com.pigma.harusari.common.auth.service.CustomUserDetailsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -58,6 +60,11 @@ public class SecurityConfig {
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter() {
         return new JwtAuthenticationFilter(jwtTokenProvider, userDetailsService);
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
     }
 
     @Bean

--- a/backend/src/main/java/com/pigma/harusari/user/query/controller/UserQueryController.java
+++ b/backend/src/main/java/com/pigma/harusari/user/query/controller/UserQueryController.java
@@ -1,12 +1,12 @@
 package com.pigma.harusari.user.query.controller;
 
+import com.pigma.harusari.common.auth.model.CustomUserDetails;
 import com.pigma.harusari.common.dto.ApiResponse;
 import com.pigma.harusari.user.query.dto.UserProfileResponse;
 import com.pigma.harusari.user.query.service.UserQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,7 +20,7 @@ public class UserQueryController {
 
     @GetMapping("/mypage")
     public ResponseEntity<ApiResponse<UserProfileResponse>> getProfile(
-            @AuthenticationPrincipal UserDetails userDetails
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         Long userId = Long.valueOf(userDetails.getUsername());
         UserProfileResponse profile = userQueryService.getUserProfile(userId);

--- a/backend/src/test/java/com/pigma/harusari/alarm/command/controller/AlarmCommandControllerTest.java
+++ b/backend/src/test/java/com/pigma/harusari/alarm/command/controller/AlarmCommandControllerTest.java
@@ -2,6 +2,7 @@ package com.pigma.harusari.alarm.command.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pigma.harusari.alarm.command.service.AlarmCommandServiceImpl;
+import com.pigma.harusari.support.WithMockCustomUser;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,7 +10,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.Mockito.doNothing;
@@ -31,7 +31,7 @@ class AlarmCommandControllerTest {
     private ObjectMapper objectMapper;
 
     @Test
-    @WithMockUser(username = "1") // username이 Long형 memberId로 사용됨
+    @WithMockCustomUser(memberId = 1L)
     @DisplayName("[알림 전체 읽음 처리] 인증된 사용자로 요청 시 성공")
     void testMarkAllAsReadSuccess() throws Exception {
         // given

--- a/backend/src/test/java/com/pigma/harusari/alarm/query/controller/AlarmQueryControllerTest.java
+++ b/backend/src/test/java/com/pigma/harusari/alarm/query/controller/AlarmQueryControllerTest.java
@@ -2,13 +2,13 @@ package com.pigma.harusari.alarm.query.controller;
 
 import com.pigma.harusari.alarm.query.dto.AlarmResponseDto;
 import com.pigma.harusari.alarm.query.service.AlarmQueryService;
+import com.pigma.harusari.support.WithMockCustomUser;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Date;
@@ -29,7 +29,7 @@ public class AlarmQueryControllerTest {
     private AlarmQueryService alarmQueryService;
 
     @Test
-    @WithMockUser(username = "1")
+    @WithMockCustomUser(memberId = 1L)
     @DisplayName("[미확인 알림 조회] 인증된 사용자로 요청 시 성공")
     void testGetUnreadAlarms() throws Exception {
         // given

--- a/backend/src/test/java/com/pigma/harusari/alarm/sse/SseControllerTest.java
+++ b/backend/src/test/java/com/pigma/harusari/alarm/sse/SseControllerTest.java
@@ -1,13 +1,12 @@
 package com.pigma.harusari.alarm.sse;
 
+import com.pigma.harusari.support.WithMockCustomUser;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -27,7 +26,7 @@ class SseControllerTest {
     private SseService sseService;
 
     @Test
-    @WithMockUser(username = "1")
+    @WithMockCustomUser(memberId = 1L)
     @DisplayName("[SSE 구독] SSE 구독 성공 테스트")
     void testSubscribeSuccess() throws Exception {
         // given

--- a/backend/src/test/java/com/pigma/harusari/alarm/sse/SseControllerTest.java
+++ b/backend/src/test/java/com/pigma/harusari/alarm/sse/SseControllerTest.java
@@ -7,7 +7,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;

--- a/backend/src/test/java/com/pigma/harusari/support/MemberTestFactory.java
+++ b/backend/src/test/java/com/pigma/harusari/support/MemberTestFactory.java
@@ -1,0 +1,25 @@
+package com.pigma.harusari.support;
+
+import com.pigma.harusari.user.command.entity.Gender;
+import com.pigma.harusari.user.command.entity.Member;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+
+/* 테스트용 Member 객체 생성 메서드를 위한 팩토리 구현 */
+public class MemberTestFactory {
+
+    public static Member testInstanceWithId(Long memberId) {
+        Member member = Member.builder()
+                .email("test@domain.com")
+                .password("encodedPassword")
+                .nickname("테스터")
+                .gender(Gender.FEMALE)
+                .consentPersonalInfo(true)
+                .userRegisteredAt(LocalDateTime.now())
+                .build();
+
+        ReflectionTestUtils.setField(member, "memberId", memberId);
+        return member;
+    }
+}

--- a/backend/src/test/java/com/pigma/harusari/support/WithMockCustomUser.java
+++ b/backend/src/test/java/com/pigma/harusari/support/WithMockCustomUser.java
@@ -1,0 +1,18 @@
+package com.pigma.harusari.support;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/* 인증 테스트 시 사용할 커스텀 어노테이션 */
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)
+public @interface WithMockCustomUser {
+    long memberId() default 1L;
+    String email() default "test@domain.com";
+    String password() default "encodedPassword";
+}

--- a/backend/src/test/java/com/pigma/harusari/support/WithMockCustomUserSecurityContextFactory.java
+++ b/backend/src/test/java/com/pigma/harusari/support/WithMockCustomUserSecurityContextFactory.java
@@ -1,0 +1,32 @@
+package com.pigma.harusari.support;
+
+import com.pigma.harusari.common.auth.model.CustomUserDetails;
+import com.pigma.harusari.user.command.entity.Gender;
+import com.pigma.harusari.user.command.entity.Member;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import java.time.LocalDateTime;
+
+import static com.pigma.harusari.support.MemberTestFactory.testInstanceWithId;
+
+/* SecurityContext 설정용 Factory 구현 */
+public class WithMockCustomUserSecurityContextFactory implements WithSecurityContextFactory<WithMockCustomUser> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockCustomUser customUser) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+        CustomUserDetails principal = new CustomUserDetails(
+                testInstanceWithId(1L)
+        );
+
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
+
+        context.setAuthentication(authentication);
+        return context;
+    }
+}

--- a/backend/src/test/java/com/pigma/harusari/user/query/controller/UserQueryControllerTest.java
+++ b/backend/src/test/java/com/pigma/harusari/user/query/controller/UserQueryControllerTest.java
@@ -3,6 +3,7 @@ package com.pigma.harusari.user.query.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pigma.harusari.common.auth.exception.AuthErrorCode;
 import com.pigma.harusari.common.auth.exception.LogInMemberNotFoundException;
+import com.pigma.harusari.support.WithMockCustomUser;
 import com.pigma.harusari.user.query.dto.UserProfileResponse;
 import com.pigma.harusari.user.query.service.UserQueryService;
 import org.junit.jupiter.api.DisplayName;
@@ -12,7 +13,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
@@ -36,7 +36,7 @@ class UserQueryControllerTest {
 
     @Test
     @DisplayName("[회원 정보 조회] 회원 정보 조회 성공")
-    @WithMockUser(username = "1", roles = "USER")
+    @WithMockCustomUser(memberId = 1L)
     void testGetMyPage() throws Exception {
         // given
         UserProfileResponse mockResponse = UserProfileResponse.builder()
@@ -52,7 +52,6 @@ class UserQueryControllerTest {
 
         // when & then
         mockMvc.perform(get("/api/v1/users/mypage")
-                        .header("Authorization", "Bearer fake-jwt-token")  // 실제 토큰 검증은 생략됨
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
@@ -64,7 +63,7 @@ class UserQueryControllerTest {
 
     @Test
     @DisplayName("[회원 정보 조회] 존재하지 않는 회원에게 예외를 발생하는 테스트")
-    @WithMockUser(username = "999", roles = "USER")
+    @WithMockCustomUser(memberId = 999L)
     void testGetMyPageUserNotFound() throws Exception {
         // given
         Mockito.when(userQueryService.getUserProfile(anyLong()))
@@ -72,7 +71,6 @@ class UserQueryControllerTest {
 
         // when & then
         mockMvc.perform(get("/api/v1/users/mypage")
-                        .header("Authorization", "Bearer fake-jwt-token")
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.success").value(false))


### PR DESCRIPTION
Closes #44

## 🔥 작업 내용  
- CustomUserDetails, CustomUserDetailsService 구현
  - UserDetailsService를 통해 DB에서 Member를 조회하여 인증 정보 구성
  - 기존의 UserDetails 직접 호출 로직 → CustomUserDetails 기반으로 일괄 리팩토링
- 테스트 전용 MemberTestFactory 및 @WithMockCustomUser 어노테이션 추가
  - 실제 Member 객체를 주입한 SecurityContext 구성 가능
  - 인증 테스트에서 mock username이 아닌 memberId 기반 인증 시나리오 구현 가능
  - 기존 @WithMockUser 사용 부분을 @WithMockCustomUser로 대체하여 테스트 신뢰성 향상

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [ ] 코드 리뷰 반영 완료

## ✨ 관련 이슈
- #44