### PR TITLE
refactor: CustomUserDetails에서 memberId 직접 참조하도록 개선

### DIFF
--- a/backend/src/main/java/com/pigma/harusari/alarm/command/controller/AlarmCommandController.java
+++ b/backend/src/main/java/com/pigma/harusari/alarm/command/controller/AlarmCommandController.java
@@ -21,7 +21,7 @@ public class AlarmCommandController {
     public ResponseEntity<ApiResponse<Void>> markAllAsRead(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        Long memberId = Long.parseLong(userDetails.getUsername());
+        Long memberId = userDetails.getMemberId();
         alarmCommandService.markAllAsRead(memberId);
         return ResponseEntity.ok(ApiResponse.success(null));
     }

--- a/backend/src/main/java/com/pigma/harusari/alarm/query/controller/AlarmQueryController.java
+++ b/backend/src/main/java/com/pigma/harusari/alarm/query/controller/AlarmQueryController.java
@@ -24,7 +24,7 @@ public class AlarmQueryController {
     public ResponseEntity<ApiResponse<List<AlarmResponseDto>>> getUnreadAlarms(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        Long memberId = Long.parseLong(userDetails.getUsername());
+        Long memberId = userDetails.getMemberId();
 
         List<AlarmResponseDto> alarms = alarmQueryService.getUnreadAlarms(memberId);
 

--- a/backend/src/main/java/com/pigma/harusari/alarm/sse/SseController.java
+++ b/backend/src/main/java/com/pigma/harusari/alarm/sse/SseController.java
@@ -19,7 +19,7 @@ public class SseController {
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         // userDetails에서 memberId(즉 userId) 추출
-        Long memberId = Long.parseLong(userDetails.getUsername());
+        Long memberId = userDetails.getMemberId();
         return sseService.subscribe(memberId);
     }
 

--- a/backend/src/main/java/com/pigma/harusari/user/query/controller/UserQueryController.java
+++ b/backend/src/main/java/com/pigma/harusari/user/query/controller/UserQueryController.java
@@ -22,7 +22,7 @@ public class UserQueryController {
     public ResponseEntity<ApiResponse<UserProfileResponse>> getProfile(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        Long userId = Long.valueOf(userDetails.getUsername());
+        Long userId = userDetails.getMemberId();
         UserProfileResponse profile = userQueryService.getUserProfile(userId);
         return ResponseEntity.ok(ApiResponse.success(profile));
     }


### PR DESCRIPTION
Closes #49

## 🔥 작업 내용  
- CustomUserDetails 구현으로 userId를 직접 참조하도록 리팩토링
: Long.parseLong(userDetails.getUsername()) -> userDetails.getMemberId()

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [ ] 코드 리뷰 반영 완료

## ✨ 관련 이슈
- #49
