### PR TITLE
feat: 통계 차트 제목에 선택된 일자/월 표시 기능 추가 및 월별 통계 조회 오류 수정

### DIFF
--- a/frontend/src/features/statistics/components/DailyStatistics.vue
+++ b/frontend/src/features/statistics/components/DailyStatistics.vue
@@ -1,5 +1,5 @@
 <script setup>
-import {ref, onMounted, watch, nextTick} from 'vue'
+import {ref, onMounted, watch, nextTick, computed} from 'vue'
 import axios from 'axios'
 import {Chart} from 'chart.js'
 import {format} from 'date-fns'
@@ -55,12 +55,14 @@ const loadData = async () => {
   drawChart(rate)
 }
 
+const labelText = computed(() => `${props.date.getDate()}일 달성률`)
+
 watch(() => props.date, loadData, {immediate: true})
 </script>
 
 <template>
   <div class="circle-box">
-    <h4>일일 달성률</h4>
+    <h4>{{ labelText }}</h4>
     <canvas ref="chartRef" width="150" height="150"></canvas>
   </div>
 </template>

--- a/frontend/src/features/statistics/components/MonthlyStatistics.vue
+++ b/frontend/src/features/statistics/components/MonthlyStatistics.vue
@@ -1,5 +1,5 @@
 <script setup>
-import {ref, watch, nextTick} from 'vue'
+import {ref, watch, nextTick, computed} from 'vue'
 import axios from 'axios'
 import {Chart} from 'chart.js'
 import {format} from 'date-fns'
@@ -55,12 +55,14 @@ const loadData = async () => {
   drawChart(rate)
 }
 
+const labelText = computed(() => `${props.date.getMonth() + 1}월 달성률`)
+
 watch(() => props.date, loadData, {immediate: true})
 </script>
 
 <template>
   <div class="circle-box">
-    <h4>월별 달성률</h4>
+    <h4>{{ labelText }}</h4>
     <canvas ref="chartRef" width="150" height="150"></canvas>
   </div>
 </template>

--- a/frontend/src/features/statistics/views/StatisticsView.vue
+++ b/frontend/src/features/statistics/views/StatisticsView.vue
@@ -29,7 +29,9 @@ onMounted(() => {
     }
     ,
     datesSet: (info) => {
-      selectedMonth.value = new Date(info.startStr)
+      // 현재 표시 중인 달의 첫 번째 날짜 기준으로 설정
+      const currentMonth = info.view.currentStart
+      selectedMonth.value = new Date(currentMonth.getFullYear(), currentMonth.getMonth(), 1)
     }
   })
 


### PR DESCRIPTION
Closes #53

## 🔥 작업 내용  
- 일일 통계 차트 제목에 선택한 일(day) 표시 (예: 15일 달성률)
- 월별 통계 차트 제목에 선택한 월(month) 표시 (예: 4월 달성률)
- 월별 통계 API 연동 시 날짜 파라미터 정상 적용
- 월별 통계가 정상적으로 조회되지 않던 문제를 수정

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [x] 코드 리뷰 반영 완료

## ✨ 관련 이슈
- #53 