### PR TITLE
chore: springdoc-openapi 2.7.0 버전으로 업그레이드 및 SwaggerConfig 설정 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 
     // swagger
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
     // security
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/backend/src/main/java/com/pigma/harusari/common/config/SecurityConfig.java
+++ b/backend/src/main/java/com/pigma/harusari/common/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import com.pigma.harusari.common.auth.service.CustomUserDetailsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -43,6 +44,7 @@ public class SecurityConfig {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/swagger", "/swagger-ui.html", "/swagger-ui/**", "/api-docs", "/api-docs/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/api/v1/auth/**").permitAll()
                         .requestMatchers("/test/daily","/test/monthly","test/weekly","test/send").permitAll()
                         .anyRequest().authenticated()

--- a/backend/src/main/java/com/pigma/harusari/common/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/pigma/harusari/common/config/SwaggerConfig.java
@@ -1,0 +1,24 @@
+package com.pigma.harusari.common.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(swaggerInfo());
+    }
+
+    private Info swaggerInfo() {
+        return new Info()
+                .title("harusari SERVER API")
+                .description("하루 살이 API 명세서")
+                .version("v1.0.0");
+    }
+
+}


### PR DESCRIPTION
Closes #64

## 🔥 작업 내용  
- springdoc-openapi-starter-webmvc-ui 버전 2.2.0 → 2.7.0으로 변경
- SwaggerConfig.java 추가
- `/swagger-ui/index.html`에 접근할 수 있도록 SecurityConfig.java에 설정 추가

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [x] 코드 리뷰 반영 완료

## ✨ 관련 이슈
- #64 
