### PR TITLE
docs: 통계 API 명세 작성을 위한 Swagger 어노테이션 적용

### DIFF
--- a/backend/src/main/java/com/pigma/harusari/statistics/query/controller/StatisticsController.java
+++ b/backend/src/main/java/com/pigma/harusari/statistics/query/controller/StatisticsController.java
@@ -7,6 +7,9 @@ import com.pigma.harusari.statistics.query.dto.response.StatisticsDayResponse;
 import com.pigma.harusari.statistics.query.dto.response.StatisticsMonthResponse;
 import com.pigma.harusari.statistics.query.service.StatisticsService;
 import com.pigma.harusari.statistics.query.utils.StatisticsRequestParser;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -20,6 +23,7 @@ import java.time.LocalDateTime;
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
+@Tag(name = "통계 API", description = "일일 통계, 월별 통계, 카테고리별 통계 API")
 public class StatisticsController {
 
     private static final long STATISTICS_DAY_RANGE = 1L;
@@ -29,6 +33,12 @@ public class StatisticsController {
     private final StatisticsService statisticsService;
 
     @GetMapping("/statistics/daily")
+    @Operation(
+            summary = "일일 통계 조회",
+            description = "쿼리 파라미터에 yyyy-MM-dd 형식으로 요청되면 해당 일을 기준으로 타입, 날짜, 완료 퍼센트를 전달한다."
+    )
+    @Parameter(name = "date", description = "요청할 날짜", example = "2022-01-01")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "요청한 날짜의 일일 통계 정보를 반환한다.")
     public ResponseEntity<ApiResponse<StatisticsDayResponse>> getStatisticsDaily(
             @RequestParam(value = "date") @Nullable String date,
             @AuthenticationPrincipal CustomUserDetails userDetails
@@ -48,6 +58,12 @@ public class StatisticsController {
     }
 
     @GetMapping("/statistics/monthly")
+    @Operation(
+            summary = "월별 통계 조회",
+            description = "쿼리 파라미터에 yyyy-MM-dd 형식으로 요청되면 해당 월을 기준으로 타입, 날짜, 완료 퍼센트를 전달한다."
+    )
+    @Parameter(name = "date", description = "요청할 날짜", example = "2022-01-01")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "요청한 날짜의 월별 통계 정보를 반환한다.")
     public ResponseEntity<ApiResponse<StatisticsMonthResponse>> getStatisticsMonthly(
             @RequestParam(value = "date") @Nullable String date,
             @AuthenticationPrincipal CustomUserDetails userDetails
@@ -67,6 +83,11 @@ public class StatisticsController {
     }
 
     @GetMapping("/statistics/category")
+    @Operation(
+            summary = "카테고리별 통계 조회",
+            description = "회원 개인의 각 카테고리별 타입, 카테고리명, 색상, 완료 퍼센트를 전달한다."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "카테고리별 통계 정보를 반환한다.")
     public ResponseEntity<ApiResponse<StatisticsCategoryResponse>> getStatisticsCategory(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {


### PR DESCRIPTION
Closes #66

## 🔥 작업 내용  
- `@Tag` 어노테이션을 사용해 `StatisticsController`를 "통계 API" 그룹으로 명시  
- `/statistics/daily` 엔드포인트에 다음 어노테이션 추가  
  - `@Operation`: API 기능 요약 및 설명  
  - `@Parameter`: 날짜 파라미터 설명  
  - `@ApiResponse`: 성공 응답 설명  
- `/statistics/monthly` 엔드포인트에 다음 어노테이션 추가  
  - `@Operation`, `@Parameter`, `@ApiResponse`를 활용하여 명세화  
- `/statistics/category` 엔드포인트에 다음 어노테이션 추가  
  - `@Operation`: API 설명  
  - `@ApiResponse`: 응답 명세 정의

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [x] 코드 리뷰 반영 완료

## ✨ 관련 이슈
- #66
