### PR TITLE
feat: 소셜 로그인(카카오) 기능 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -69,6 +69,9 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
 
+    // webflux
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
     // devtools
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 

--- a/backend/src/main/java/com/pigma/harusari/common/config/WebClientConfig.java
+++ b/backend/src/main/java/com/pigma/harusari/common/config/WebClientConfig.java
@@ -1,0 +1,14 @@
+package com.pigma.harusari.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient(WebClient.Builder builder) {
+        return builder.build();
+    }
+}

--- a/backend/src/main/java/com/pigma/harusari/common/oauth/controller/KakaoAuthController.java
+++ b/backend/src/main/java/com/pigma/harusari/common/oauth/controller/KakaoAuthController.java
@@ -1,0 +1,26 @@
+package com.pigma.harusari.common.oauth.controller;
+
+import com.pigma.harusari.common.dto.ApiResponse;
+import com.pigma.harusari.common.oauth.dto.KakaoUserBasicInfo;
+import com.pigma.harusari.common.oauth.service.KakaoAuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/auth/social")
+@RequiredArgsConstructor
+public class KakaoAuthController {
+
+    private final KakaoAuthService kakaoAuthService;
+
+    /* 카카오 회원가입 - 사용자 정보만 조회(실제 가입은 X) */
+    @GetMapping("/info/kakao")
+    public ResponseEntity<ApiResponse<KakaoUserBasicInfo>> getKakaoUserInfo(
+            @RequestParam String code
+    ) {
+        KakaoUserBasicInfo userInfo = kakaoAuthService.getUserInfo(code);
+        return ResponseEntity.ok(ApiResponse.success(userInfo));
+    }
+
+}

--- a/backend/src/main/java/com/pigma/harusari/common/oauth/controller/KakaoAuthController.java
+++ b/backend/src/main/java/com/pigma/harusari/common/oauth/controller/KakaoAuthController.java
@@ -1,6 +1,8 @@
 package com.pigma.harusari.common.oauth.controller;
 
+import com.pigma.harusari.common.auth.dto.LoginResponse;
 import com.pigma.harusari.common.dto.ApiResponse;
+import com.pigma.harusari.common.oauth.dto.KakaoSignupRequest;
 import com.pigma.harusari.common.oauth.dto.KakaoUserBasicInfo;
 import com.pigma.harusari.common.oauth.service.KakaoAuthService;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +23,15 @@ public class KakaoAuthController {
     ) {
         KakaoUserBasicInfo userInfo = kakaoAuthService.getUserInfo(code);
         return ResponseEntity.ok(ApiResponse.success(userInfo));
+    }
+
+    /* 카카오 회원가입 - 최종 회원가입 처리(성별, 개인정보 동의 등) */
+    @PostMapping("/signup/kakao")
+    public ResponseEntity<ApiResponse<LoginResponse>> signupWithKakao(
+            @RequestBody KakaoSignupRequest request
+    ) {
+        LoginResponse response = kakaoAuthService.signup(request);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
 }

--- a/backend/src/main/java/com/pigma/harusari/common/oauth/controller/KakaoAuthController.java
+++ b/backend/src/main/java/com/pigma/harusari/common/oauth/controller/KakaoAuthController.java
@@ -34,4 +34,13 @@ public class KakaoAuthController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
+    /* 카카오 로그인 */
+    @GetMapping("/login/kakao")
+    public ResponseEntity<ApiResponse<LoginResponse>> loginWithKakao(
+            @RequestParam String code
+    ) {
+        LoginResponse response = kakaoAuthService.login(code);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
 }

--- a/backend/src/main/java/com/pigma/harusari/common/oauth/dto/KakaoSignupRequest.java
+++ b/backend/src/main/java/com/pigma/harusari/common/oauth/dto/KakaoSignupRequest.java
@@ -1,0 +1,12 @@
+package com.pigma.harusari.common.oauth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class KakaoSignupRequest {
+
+    private String email;
+    private String nickname;
+    private Boolean consentPersonalInfo;
+
+}

--- a/backend/src/main/java/com/pigma/harusari/common/oauth/dto/KakaoSignupRequest.java
+++ b/backend/src/main/java/com/pigma/harusari/common/oauth/dto/KakaoSignupRequest.java
@@ -1,14 +1,30 @@
 package com.pigma.harusari.common.oauth.dto;
 
+import com.pigma.harusari.category.command.application.dto.request.CategoryCreateRequest;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.List;
 
 @Getter
 @Builder
 public class KakaoSignupRequest {
 
+    @NotBlank(message = "이메일은 필수입니다.")
     private String email;
+
+    @NotBlank(message = "닉네임은 필수입니다.")
     private String nickname;
+
+    @NotBlank(message = "성별은 필수입니다.")
+    private String gender; // "MALE", "FEMALE", "NONE"
+
+    @NotNull(message = "개인정보 수집 동의는 필수입니다.")
     private Boolean consentPersonalInfo;
 
+    @NotEmpty(message = "최소 하나 이상의 카테고리를 선택해야 합니다.")
+    private List<CategoryCreateRequest> categoryList;
 }

--- a/backend/src/main/java/com/pigma/harusari/common/oauth/dto/KakaoSignupRequest.java
+++ b/backend/src/main/java/com/pigma/harusari/common/oauth/dto/KakaoSignupRequest.java
@@ -1,8 +1,10 @@
 package com.pigma.harusari.common.oauth.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 public class KakaoSignupRequest {
 
     private String email;

--- a/backend/src/main/java/com/pigma/harusari/common/oauth/dto/KakaoTokenResponse.java
+++ b/backend/src/main/java/com/pigma/harusari/common/oauth/dto/KakaoTokenResponse.java
@@ -1,9 +1,11 @@
 package com.pigma.harusari.common.oauth.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 public class KakaoTokenResponse {
 
     @JsonProperty("access_token")

--- a/backend/src/main/java/com/pigma/harusari/common/oauth/dto/KakaoTokenResponse.java
+++ b/backend/src/main/java/com/pigma/harusari/common/oauth/dto/KakaoTokenResponse.java
@@ -1,0 +1,23 @@
+package com.pigma.harusari.common.oauth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class KakaoTokenResponse {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("expires_in")
+    private Long expiresIn;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("refresh_token_expires_in")
+    private Long refreshTokenExpiresIn;
+}

--- a/backend/src/main/java/com/pigma/harusari/common/oauth/dto/KakaoUserBasicInfo.java
+++ b/backend/src/main/java/com/pigma/harusari/common/oauth/dto/KakaoUserBasicInfo.java
@@ -1,0 +1,16 @@
+package com.pigma.harusari.common.oauth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class KakaoUserBasicInfo {
+
+    private String email;
+    private String nickname;
+
+    public KakaoUserBasicInfo(String email, String nickname) {
+        this.email = email;
+        this.nickname = nickname;
+    }
+
+}

--- a/backend/src/main/java/com/pigma/harusari/common/oauth/dto/KakaoUserInfo.java
+++ b/backend/src/main/java/com/pigma/harusari/common/oauth/dto/KakaoUserInfo.java
@@ -1,9 +1,11 @@
 package com.pigma.harusari.common.oauth.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 public class KakaoUserInfo {
 
     private Long id;
@@ -12,11 +14,13 @@ public class KakaoUserInfo {
     private KakaoAccount kakao_account;
 
     @Getter
+    @Builder
     public static class KakaoAccount {
         private String email;
         private Profile profile;
 
         @Getter
+        @Builder
         public static class Profile {
             private String nickname;
         }

--- a/backend/src/main/java/com/pigma/harusari/common/oauth/dto/KakaoUserInfo.java
+++ b/backend/src/main/java/com/pigma/harusari/common/oauth/dto/KakaoUserInfo.java
@@ -1,0 +1,24 @@
+package com.pigma.harusari.common.oauth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class KakaoUserInfo {
+
+    private Long id;
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakao_account;
+
+    @Getter
+    public static class KakaoAccount {
+        private String email;
+        private Profile profile;
+
+        @Getter
+        public static class Profile {
+            private String nickname;
+        }
+    }
+}

--- a/backend/src/main/java/com/pigma/harusari/common/oauth/exception/OAuthAlreadyRegisteredException.java
+++ b/backend/src/main/java/com/pigma/harusari/common/oauth/exception/OAuthAlreadyRegisteredException.java
@@ -1,0 +1,15 @@
+package com.pigma.harusari.common.oauth.exception;
+
+import lombok.Getter;
+
+@Getter
+public class OAuthAlreadyRegisteredException extends RuntimeException {
+
+    private final OAuthExceptionErrorCode errorCode;
+
+    public OAuthAlreadyRegisteredException(OAuthExceptionErrorCode errorCode) {
+        super(errorCode.getErrorMessage());
+        this.errorCode = errorCode;
+    }
+
+}

--- a/backend/src/main/java/com/pigma/harusari/common/oauth/exception/OAuthExceptionErrorCode.java
+++ b/backend/src/main/java/com/pigma/harusari/common/oauth/exception/OAuthExceptionErrorCode.java
@@ -15,6 +15,7 @@ public enum OAuthExceptionErrorCode {
     OAUTH_ALREADY_REGISTERED("12005", "이미 가입된 이메일입니다.", HttpStatus.CONFLICT),
     OAUTH_REDIS_SAVE_FAILED("12006", "리프레시 토큰 저장 중 문제가 발생했습니다.", HttpStatus.SERVICE_UNAVAILABLE),
     OAUTH_JWT_ISSUE_FAILED("12007", "로그인 토큰 발급 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    OAUTH_USER_NOT_FOUND("12008", "가입되지 않은 카카오 사용자입니다.", HttpStatus.UNAUTHORIZED),
     OAUTH_INTERNAL_ERROR("12999", "소셜 인증 처리 중 알 수 없는 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final String errorCode;

--- a/backend/src/main/java/com/pigma/harusari/common/oauth/exception/OAuthExceptionErrorCode.java
+++ b/backend/src/main/java/com/pigma/harusari/common/oauth/exception/OAuthExceptionErrorCode.java
@@ -1,0 +1,20 @@
+package com.pigma.harusari.common.oauth.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum OAuthExceptionErrorCode {
+
+    OAUTH_USER_INFO_INCOMPLETE("12004", "카카오 사용자 정보에 이메일 또는 닉네임이 없습니다.", HttpStatus.BAD_REQUEST),
+    OAUTH_TOKEN_REQUEST_FAILED("12002", "카카오 토큰 요청 중 오류가 발생했습니다.", HttpStatus.BAD_GATEWAY),
+    OAUTH_INVALID_CODE("12001", "잘못되었거나 만료된 인가 코드입니다.", HttpStatus.BAD_REQUEST),
+    OAUTH_USER_INFO_REQUEST_FAILED("12003", "카카오 사용자 정보를 가져오는 데 실패했습니다.", HttpStatus.BAD_GATEWAY),;
+
+    private final String errorCode;
+    private final String errorMessage;
+    private final HttpStatus httpStatus;
+
+}

--- a/backend/src/main/java/com/pigma/harusari/common/oauth/exception/OAuthExceptionErrorCode.java
+++ b/backend/src/main/java/com/pigma/harusari/common/oauth/exception/OAuthExceptionErrorCode.java
@@ -8,10 +8,14 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum OAuthExceptionErrorCode {
 
-    OAUTH_USER_INFO_INCOMPLETE("12004", "카카오 사용자 정보에 이메일 또는 닉네임이 없습니다.", HttpStatus.BAD_REQUEST),
+    OAUTH_USER_INFO_INCOMPLETE("12001", "카카오 사용자 정보에 이메일 또는 닉네임이 없습니다.", HttpStatus.BAD_REQUEST),
     OAUTH_TOKEN_REQUEST_FAILED("12002", "카카오 토큰 요청 중 오류가 발생했습니다.", HttpStatus.BAD_GATEWAY),
-    OAUTH_INVALID_CODE("12001", "잘못되었거나 만료된 인가 코드입니다.", HttpStatus.BAD_REQUEST),
-    OAUTH_USER_INFO_REQUEST_FAILED("12003", "카카오 사용자 정보를 가져오는 데 실패했습니다.", HttpStatus.BAD_GATEWAY),;
+    OAUTH_INVALID_CODE("12003", "잘못되었거나 만료된 인가 코드입니다.", HttpStatus.BAD_REQUEST),
+    OAUTH_USER_INFO_REQUEST_FAILED("12004", "카카오 사용자 정보를 가져오는 데 실패했습니다.", HttpStatus.BAD_GATEWAY),
+    OAUTH_ALREADY_REGISTERED("12005", "이미 가입된 이메일입니다.", HttpStatus.CONFLICT),
+    OAUTH_REDIS_SAVE_FAILED("12006", "리프레시 토큰 저장 중 문제가 발생했습니다.", HttpStatus.SERVICE_UNAVAILABLE),
+    OAUTH_JWT_ISSUE_FAILED("12007", "로그인 토큰 발급 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    OAUTH_INTERNAL_ERROR("12999", "소셜 인증 처리 중 알 수 없는 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final String errorCode;
     private final String errorMessage;

--- a/backend/src/main/java/com/pigma/harusari/common/oauth/exception/OAuthInternalErrorException.java
+++ b/backend/src/main/java/com/pigma/harusari/common/oauth/exception/OAuthInternalErrorException.java
@@ -1,0 +1,15 @@
+package com.pigma.harusari.common.oauth.exception;
+
+import lombok.Getter;
+
+@Getter
+public class OAuthInternalErrorException extends RuntimeException {
+
+    private final OAuthExceptionErrorCode errorCode;
+
+    public OAuthInternalErrorException(OAuthExceptionErrorCode errorCode) {
+        super(errorCode.getErrorMessage());
+        this.errorCode = errorCode;
+    }
+
+}

--- a/backend/src/main/java/com/pigma/harusari/common/oauth/exception/OAuthInvalidCodeException.java
+++ b/backend/src/main/java/com/pigma/harusari/common/oauth/exception/OAuthInvalidCodeException.java
@@ -1,0 +1,15 @@
+package com.pigma.harusari.common.oauth.exception;
+
+import lombok.Getter;
+
+@Getter
+public class OAuthInvalidCodeException extends RuntimeException {
+
+    private final OAuthExceptionErrorCode errorCode;
+
+    public OAuthInvalidCodeException(OAuthExceptionErrorCode errorCode) {
+        super(errorCode.getErrorMessage());
+        this.errorCode = errorCode;
+    }
+
+}

--- a/backend/src/main/java/com/pigma/harusari/common/oauth/exception/OAuthJWTIssutFailedException.java
+++ b/backend/src/main/java/com/pigma/harusari/common/oauth/exception/OAuthJWTIssutFailedException.java
@@ -1,0 +1,15 @@
+package com.pigma.harusari.common.oauth.exception;
+
+import lombok.Getter;
+
+@Getter
+public class OAuthJWTIssutFailedException extends RuntimeException {
+
+    private final OAuthExceptionErrorCode errorCode;
+
+    public OAuthJWTIssutFailedException(OAuthExceptionErrorCode errorCode) {
+        super(errorCode.getErrorMessage());
+        this.errorCode = errorCode;
+    }
+
+}

--- a/backend/src/main/java/com/pigma/harusari/common/oauth/exception/OAuthRedisSaveFailedException.java
+++ b/backend/src/main/java/com/pigma/harusari/common/oauth/exception/OAuthRedisSaveFailedException.java
@@ -1,0 +1,15 @@
+package com.pigma.harusari.common.oauth.exception;
+
+import lombok.Getter;
+
+@Getter
+public class OAuthRedisSaveFailedException extends RuntimeException {
+
+    private final OAuthExceptionErrorCode errorCode;
+
+    public OAuthRedisSaveFailedException(OAuthExceptionErrorCode errorCode) {
+        super(errorCode.getErrorMessage());
+        this.errorCode = errorCode;
+    }
+
+}

--- a/backend/src/main/java/com/pigma/harusari/common/oauth/exception/OAuthTokenRequestFailedException.java
+++ b/backend/src/main/java/com/pigma/harusari/common/oauth/exception/OAuthTokenRequestFailedException.java
@@ -1,0 +1,15 @@
+package com.pigma.harusari.common.oauth.exception;
+
+import lombok.Getter;
+
+@Getter
+public class OAuthTokenRequestFailedException extends RuntimeException {
+
+    private final OAuthExceptionErrorCode errorCode;
+
+    public OAuthTokenRequestFailedException(OAuthExceptionErrorCode errorCode) {
+        super(errorCode.getErrorMessage());
+        this.errorCode = errorCode;
+    }
+
+}

--- a/backend/src/main/java/com/pigma/harusari/common/oauth/exception/OAuthUserInfoIncompleteException.java
+++ b/backend/src/main/java/com/pigma/harusari/common/oauth/exception/OAuthUserInfoIncompleteException.java
@@ -1,0 +1,15 @@
+package com.pigma.harusari.common.oauth.exception;
+
+import lombok.Getter;
+
+@Getter
+public class OAuthUserInfoIncompleteException extends RuntimeException {
+
+    private final OAuthExceptionErrorCode errorCode;
+
+    public OAuthUserInfoIncompleteException(OAuthExceptionErrorCode errorCode) {
+        super(errorCode.getErrorMessage());
+        this.errorCode = errorCode;
+    }
+
+}

--- a/backend/src/main/java/com/pigma/harusari/common/oauth/exception/OAuthUserInfoRequestFailedException.java
+++ b/backend/src/main/java/com/pigma/harusari/common/oauth/exception/OAuthUserInfoRequestFailedException.java
@@ -1,0 +1,15 @@
+package com.pigma.harusari.common.oauth.exception;
+
+import lombok.Getter;
+
+@Getter
+public class OAuthUserInfoRequestFailedException extends RuntimeException {
+
+    private final OAuthExceptionErrorCode errorCode;
+
+    public OAuthUserInfoRequestFailedException(OAuthExceptionErrorCode errorCode) {
+        super(errorCode.getErrorMessage());
+        this.errorCode = errorCode;
+    }
+
+}

--- a/backend/src/main/java/com/pigma/harusari/common/oauth/exception/OAuthUserNotFoundException.java
+++ b/backend/src/main/java/com/pigma/harusari/common/oauth/exception/OAuthUserNotFoundException.java
@@ -1,0 +1,15 @@
+package com.pigma.harusari.common.oauth.exception;
+
+import lombok.Getter;
+
+@Getter
+public class OAuthUserNotFoundException extends RuntimeException {
+
+    private final OAuthExceptionErrorCode errorCode;
+
+    public OAuthUserNotFoundException(OAuthExceptionErrorCode errorCode) {
+        super(errorCode.getErrorMessage());
+        this.errorCode = errorCode;
+    }
+
+}

--- a/backend/src/main/java/com/pigma/harusari/common/oauth/exception/handler/OAuthExceptionHandler.java
+++ b/backend/src/main/java/com/pigma/harusari/common/oauth/exception/handler/OAuthExceptionHandler.java
@@ -1,0 +1,40 @@
+package com.pigma.harusari.common.oauth.exception.handler;
+
+import com.pigma.harusari.common.dto.ApiResponse;
+import com.pigma.harusari.common.oauth.exception.*;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class OAuthExceptionHandler {
+
+    @ExceptionHandler(OAuthUserInfoRequestFailedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleOAuthUserInfoRequestFailedException(OAuthUserInfoRequestFailedException e) {
+        OAuthExceptionErrorCode errorCode = e.getErrorCode();
+        ApiResponse<Void> response = ApiResponse.failure(errorCode.getErrorCode(), errorCode.getErrorMessage());
+        return new ResponseEntity<>(response, errorCode.getHttpStatus());
+    }
+
+    @ExceptionHandler(OAuthTokenRequestFailedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleOAuthTokenRequestFailedException(OAuthTokenRequestFailedException e) {
+        OAuthExceptionErrorCode errorCode = e.getErrorCode();
+        ApiResponse<Void> response = ApiResponse.failure(errorCode.getErrorCode(), errorCode.getErrorMessage());
+        return new ResponseEntity<>(response, errorCode.getHttpStatus());
+    }
+
+    @ExceptionHandler(OAuthInvalidCodeException.class)
+    public ResponseEntity<ApiResponse<Void>> handleOAuthInvalidCodeException(OAuthInvalidCodeException e) {
+        OAuthExceptionErrorCode errorCode = e.getErrorCode();
+        ApiResponse<Void> response = ApiResponse.failure(errorCode.getErrorCode(), errorCode.getErrorMessage());
+        return new ResponseEntity<>(response, errorCode.getHttpStatus());
+    }
+
+    @ExceptionHandler(OAuthUserInfoIncompleteException.class)
+    public ResponseEntity<ApiResponse<Void>> handleOAuthUserInfoIncompleteException(OAuthUserInfoIncompleteException e) {
+        OAuthExceptionErrorCode errorCode = e.getErrorCode();
+        ApiResponse<Void> response = ApiResponse.failure(errorCode.getErrorCode(), errorCode.getErrorMessage());
+        return new ResponseEntity<>(response, errorCode.getHttpStatus());
+    }
+
+}

--- a/backend/src/main/java/com/pigma/harusari/common/oauth/exception/handler/OAuthExceptionHandler.java
+++ b/backend/src/main/java/com/pigma/harusari/common/oauth/exception/handler/OAuthExceptionHandler.java
@@ -37,4 +37,32 @@ public class OAuthExceptionHandler {
         return new ResponseEntity<>(response, errorCode.getHttpStatus());
     }
 
+    @ExceptionHandler(OAuthAlreadyRegisteredException.class)
+    public ResponseEntity<ApiResponse<Void>> handleOAuthAlreadyRegisteredException(OAuthAlreadyRegisteredException e) {
+        OAuthExceptionErrorCode errorCode = e.getErrorCode();
+        ApiResponse<Void> response = ApiResponse.failure(errorCode.getErrorCode(), errorCode.getErrorMessage());
+        return new ResponseEntity<>(response, errorCode.getHttpStatus());
+    }
+
+    @ExceptionHandler(OAuthRedisSaveFailedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleOAuthRedisSaveFailedException(OAuthRedisSaveFailedException e) {
+        OAuthExceptionErrorCode errorCode = e.getErrorCode();
+        ApiResponse<Void> response = ApiResponse.failure(errorCode.getErrorCode(), errorCode.getErrorMessage());
+        return new ResponseEntity<>(response, errorCode.getHttpStatus());
+    }
+
+    @ExceptionHandler(OAuthJWTIssutFailedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleOAuthJWTIssutFailedException(OAuthJWTIssutFailedException e) {
+        OAuthExceptionErrorCode errorCode = e.getErrorCode();
+        ApiResponse<Void> response = ApiResponse.failure(errorCode.getErrorCode(), errorCode.getErrorMessage());
+        return new ResponseEntity<>(response, errorCode.getHttpStatus());
+    }
+
+    @ExceptionHandler(OAuthInternalErrorException.class)
+    public ResponseEntity<ApiResponse<Void>> handleOAuthInternalErrorException(OAuthInternalErrorException e) {
+        OAuthExceptionErrorCode errorCode = e.getErrorCode();
+        ApiResponse<Void> response = ApiResponse.failure(errorCode.getErrorCode(), errorCode.getErrorMessage());
+        return new ResponseEntity<>(response, errorCode.getHttpStatus());
+    }
+
 }

--- a/backend/src/main/java/com/pigma/harusari/common/oauth/exception/handler/OAuthExceptionHandler.java
+++ b/backend/src/main/java/com/pigma/harusari/common/oauth/exception/handler/OAuthExceptionHandler.java
@@ -65,4 +65,11 @@ public class OAuthExceptionHandler {
         return new ResponseEntity<>(response, errorCode.getHttpStatus());
     }
 
+    @ExceptionHandler(OAuthUserNotFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleOAuthUserNotFoundException(OAuthUserNotFoundException e) {
+        OAuthExceptionErrorCode errorCode = e.getErrorCode();
+        ApiResponse<Void> response = ApiResponse.failure(errorCode.getErrorCode(), errorCode.getErrorMessage());
+        return new ResponseEntity<>(response, errorCode.getHttpStatus());
+    }
+
 }

--- a/backend/src/main/java/com/pigma/harusari/common/oauth/service/KakaoAuthService.java
+++ b/backend/src/main/java/com/pigma/harusari/common/oauth/service/KakaoAuthService.java
@@ -8,5 +8,6 @@ public interface KakaoAuthService {
 
     KakaoUserBasicInfo getUserInfo(String code);
     LoginResponse signup(KakaoSignupRequest request);
+    LoginResponse login(String code);
 
 }

--- a/backend/src/main/java/com/pigma/harusari/common/oauth/service/KakaoAuthService.java
+++ b/backend/src/main/java/com/pigma/harusari/common/oauth/service/KakaoAuthService.java
@@ -1,0 +1,9 @@
+package com.pigma.harusari.common.oauth.service;
+
+import com.pigma.harusari.common.oauth.dto.KakaoUserBasicInfo;
+
+public interface KakaoAuthService {
+
+    KakaoUserBasicInfo getUserInfo(String code);
+
+}

--- a/backend/src/main/java/com/pigma/harusari/common/oauth/service/KakaoAuthService.java
+++ b/backend/src/main/java/com/pigma/harusari/common/oauth/service/KakaoAuthService.java
@@ -1,9 +1,12 @@
 package com.pigma.harusari.common.oauth.service;
 
+import com.pigma.harusari.common.auth.dto.LoginResponse;
+import com.pigma.harusari.common.oauth.dto.KakaoSignupRequest;
 import com.pigma.harusari.common.oauth.dto.KakaoUserBasicInfo;
 
 public interface KakaoAuthService {
 
     KakaoUserBasicInfo getUserInfo(String code);
+    LoginResponse signup(KakaoSignupRequest request);
 
 }

--- a/backend/src/main/java/com/pigma/harusari/common/oauth/service/KakaoAuthServiceImpl.java
+++ b/backend/src/main/java/com/pigma/harusari/common/oauth/service/KakaoAuthServiceImpl.java
@@ -1,0 +1,82 @@
+package com.pigma.harusari.common.oauth.service;
+
+import com.pigma.harusari.common.oauth.dto.*;
+import com.pigma.harusari.common.oauth.exception.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class KakaoAuthServiceImpl implements KakaoAuthService {
+
+    private final WebClient webClient;
+
+    @Value("${kakao.client-id}")
+    private String clientId;
+
+    @Value("${kakao.redirect-uri}")
+    private String redirectUri;
+
+    @Value("${kakao.token-uri}")
+    private String tokenUri;
+
+    @Value("${kakao.user-info-uri}")
+    private String userInfoUri;
+
+    /* 카카오 회원가입 - 사용자 정보만 조회(실제 가입은 X) */
+    @Override
+    public KakaoUserBasicInfo getUserInfo(String code) {
+        String accessToken = requestAccessToken(code).getAccessToken();
+        KakaoUserInfo kakaoUser = requestUserInfo(accessToken);
+
+        String email = kakaoUser.getKakao_account().getEmail();
+        String nickname = kakaoUser.getKakao_account().getProfile().getNickname();
+
+        if (email == null || nickname == null) {
+            throw new OAuthUserInfoIncompleteException(OAuthExceptionErrorCode.OAUTH_USER_INFO_INCOMPLETE);
+        }
+        return new KakaoUserBasicInfo(email, nickname);
+    }
+
+    /* 카카오 인가 코드 기반으로 토큰 요청 */
+    private KakaoTokenResponse requestAccessToken(String code) {
+        try {
+            return webClient.post()
+                    .uri(tokenUri)
+                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                    .body(BodyInserters
+                            .fromFormData("grant_type", "authorization_code")
+                            .with("client_id", clientId)
+                            .with("redirect_uri", redirectUri)
+                            .with("code", code))
+                    .retrieve()
+                    .bodyToMono(KakaoTokenResponse.class)
+                    .blockOptional()
+                    .orElseThrow(() -> new OAuthTokenRequestFailedException(OAuthExceptionErrorCode.OAUTH_TOKEN_REQUEST_FAILED));
+        } catch (Exception e) {
+            throw new OAuthInvalidCodeException(OAuthExceptionErrorCode.OAUTH_INVALID_CODE);
+        }
+    }
+
+    /* AccessToken 기반으로 카카오 사용자의 정보 조회 */
+    private KakaoUserInfo requestUserInfo(String accessToken) {
+        try {
+            return webClient.get()
+                    .uri(userInfoUri)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                    .retrieve()
+                    .bodyToMono(KakaoUserInfo.class)
+                    .blockOptional()
+                    .orElseThrow(() -> new OAuthUserInfoRequestFailedException(OAuthExceptionErrorCode.OAUTH_USER_INFO_REQUEST_FAILED));
+        } catch (Exception e) {
+            throw new OAuthUserInfoRequestFailedException(OAuthExceptionErrorCode.OAUTH_USER_INFO_REQUEST_FAILED);
+        }
+    }
+
+}

--- a/backend/src/main/java/com/pigma/harusari/common/oauth/service/KakaoAuthServiceImpl.java
+++ b/backend/src/main/java/com/pigma/harusari/common/oauth/service/KakaoAuthServiceImpl.java
@@ -82,6 +82,19 @@ public class KakaoAuthServiceImpl implements KakaoAuthService {
         return issueJwtTokens(saved);
     }
 
+    /* 카카오 로그인 */
+    @Override
+    public LoginResponse login(String code) {
+        String accessToken = requestAccessToken(code).getAccessToken();
+        KakaoUserInfo kakaoUser = requestUserInfo(accessToken);
+
+        String email = kakaoUser.getKakao_account().getEmail();
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new OAuthUserNotFoundException(OAuthExceptionErrorCode.OAUTH_USER_NOT_FOUND));
+
+        return issueJwtTokens(member);
+    }
+
     /* 카카오 인가 코드 기반으로 토큰 요청 */
     private KakaoTokenResponse requestAccessToken(String code) {
         try {

--- a/backend/src/main/java/com/pigma/harusari/common/oauth/service/KakaoAuthServiceImpl.java
+++ b/backend/src/main/java/com/pigma/harusari/common/oauth/service/KakaoAuthServiceImpl.java
@@ -96,7 +96,7 @@ public class KakaoAuthServiceImpl implements KakaoAuthService {
     }
 
     /* 카카오 인가 코드 기반으로 토큰 요청 */
-    private KakaoTokenResponse requestAccessToken(String code) {
+    KakaoTokenResponse requestAccessToken(String code) {
         try {
             return webClient.post()
                     .uri(tokenUri)
@@ -116,7 +116,7 @@ public class KakaoAuthServiceImpl implements KakaoAuthService {
     }
 
     /* AccessToken 기반으로 카카오 사용자의 정보 조회 */
-    private KakaoUserInfo requestUserInfo(String accessToken) {
+    KakaoUserInfo requestUserInfo(String accessToken) {
         try {
             return webClient.get()
                     .uri(userInfoUri)
@@ -131,7 +131,7 @@ public class KakaoAuthServiceImpl implements KakaoAuthService {
     }
 
     /* JWT 토큰 생성하고 리프레스 토큰을 Redis에 저장 */
-    private LoginResponse issueJwtTokens(Member member) {
+    LoginResponse issueJwtTokens(Member member) {
         try {
             String userId = String.valueOf(member.getMemberId());
             String accessToken = jwtTokenProvider.createToken(userId, member.getGender().name());

--- a/backend/src/main/java/com/pigma/harusari/user/command/entity/AuthProvider.java
+++ b/backend/src/main/java/com/pigma/harusari/user/command/entity/AuthProvider.java
@@ -1,0 +1,8 @@
+package com.pigma.harusari.user.command.entity;
+
+public enum AuthProvider {
+
+    LOCAL,
+    KAKAO
+
+}

--- a/backend/src/main/java/com/pigma/harusari/user/command/entity/Member.java
+++ b/backend/src/main/java/com/pigma/harusari/user/command/entity/Member.java
@@ -32,6 +32,10 @@ public class Member {
     @Column(name = "consent_personal_info", nullable = false)
     private Boolean consentPersonalInfo = false;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "auth_provider", nullable = false)
+    private AuthProvider provider;
+
     @Column(name = "user_registered_at", nullable = false)
     private LocalDateTime userRegisteredAt;
 
@@ -42,12 +46,13 @@ public class Member {
     private Boolean userDeletedAt = false;
 
     @Builder
-    public Member(String email, String password, String nickname, Gender gender, Boolean consentPersonalInfo, LocalDateTime userRegisteredAt) {
+    public Member(String email, String password, String nickname, Gender gender, Boolean consentPersonalInfo, AuthProvider provider, LocalDateTime userRegisteredAt) {
         this.email = email;
         this.password = password;
         this.nickname = nickname;
         this.gender = gender;
         this.consentPersonalInfo = (consentPersonalInfo != null) ? consentPersonalInfo : false;
+        this.provider = provider != null ? provider : AuthProvider.LOCAL;
         this.userRegisteredAt = (userRegisteredAt != null) ? userRegisteredAt : LocalDateTime.now();
         this.userDeletedAt = false;
     }

--- a/backend/src/main/java/com/pigma/harusari/user/command/service/UserCommandServiceImpl.java
+++ b/backend/src/main/java/com/pigma/harusari/user/command/service/UserCommandServiceImpl.java
@@ -7,6 +7,7 @@ import com.pigma.harusari.category.command.domain.repository.CategoryCommandRepo
 import com.pigma.harusari.common.auth.exception.AuthErrorCode;
 import com.pigma.harusari.common.auth.exception.LogInMemberNotFoundException;
 import com.pigma.harusari.user.command.dto.*;
+import com.pigma.harusari.user.command.entity.AuthProvider;
 import com.pigma.harusari.user.command.entity.Gender;
 import com.pigma.harusari.user.command.entity.Member;
 import com.pigma.harusari.user.command.exception.*;
@@ -61,6 +62,7 @@ public class UserCommandServiceImpl implements UserCommandService {
                 .nickname(request.getNickname())
                 .gender(gender)
                 .consentPersonalInfo(request.getConsentPersonalInfo())
+                .provider(AuthProvider.LOCAL)
                 .userRegisteredAt(LocalDateTime.now())
                 .build();
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -36,6 +36,11 @@ spring:
       mail.smtp.auth: true
       mail.smtp.starttls.enable: true
 
+kakao:
+  client-id: ${KAKAO_CLIENT_ID}
+  redirect-uri: ${KAKAO_REDIRECT_URI}
+  token-uri: ${KAKAO_TOKEN_URI}
+  user-info-uri: ${KAKAO_USER_INFO_URI}
 
 mybatis:
   configuration:
@@ -47,7 +52,7 @@ mybatis:
 jwt:
   secret: ${JWT_SECRET}
   expiration: ${JWT_EXPIRATION} # 30분
-  refresh-expiration : ${JWT_REFRESH_EXPIRATION} # 7일
+  refresh-expiration: ${JWT_REFRESH_EXPIRATION} # 7일
 
   rabbitmq:
     host: localhost

--- a/backend/src/test/java/com/pigma/harusari/common/oauth/controller/KakaoAuthControllerTest.java
+++ b/backend/src/test/java/com/pigma/harusari/common/oauth/controller/KakaoAuthControllerTest.java
@@ -1,0 +1,99 @@
+package com.pigma.harusari.common.oauth.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pigma.harusari.common.auth.dto.LoginResponse;
+import com.pigma.harusari.common.oauth.dto.KakaoSignupRequest;
+import com.pigma.harusari.common.oauth.dto.KakaoUserBasicInfo;
+import com.pigma.harusari.common.oauth.service.KakaoAuthService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(KakaoAuthController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("[카카오 - controller] KakaoAuthController 테스트")
+class KakaoAuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private KakaoAuthService kakaoAuthService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private KakaoUserBasicInfo kakaoUserBasicInfo;
+    private KakaoSignupRequest kakaoSignupRequest;
+    private LoginResponse loginResponse;
+
+    @BeforeEach
+    void setUp() {
+        kakaoUserBasicInfo = new KakaoUserBasicInfo("kakao@example.com", "카카오유저");
+
+        kakaoSignupRequest = KakaoSignupRequest.builder()
+                .email("kakao@example.com")
+                .nickname("카카오유저")
+                .consentPersonalInfo(true)
+                .build();
+
+        loginResponse = LoginResponse.builder()
+                .accessToken("access-token")
+                .refreshToken("refresh-token")
+                .nickname("카카오유저")
+                .userId(1L)
+                .build();
+    }
+
+    @Test
+    @DisplayName("[카카오 회원가입] 사용자 정보 조회 성공")
+    void testGetKakaoUserInfo() throws Exception {
+        String code = "fake-code";
+        when(kakaoAuthService.getUserInfo(code)).thenReturn(kakaoUserBasicInfo);
+
+        mockMvc.perform(get("/api/v1/auth/social/info/kakao")
+                        .param("code", code))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.email").value(kakaoUserBasicInfo.getEmail()))
+                .andExpect(jsonPath("$.data.nickname").value(kakaoUserBasicInfo.getNickname()));
+    }
+
+    @Test
+    @DisplayName("[카카오 회원가입] 최종 회원가입 성공")
+    void testSignupWithKakao() throws Exception {
+        when(kakaoAuthService.signup(any(KakaoSignupRequest.class))).thenReturn(loginResponse);
+
+        mockMvc.perform(post("/api/v1/auth/social/signup/kakao")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(kakaoSignupRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.accessToken").value(loginResponse.getAccessToken()))
+                .andExpect(jsonPath("$.data.userId").value(loginResponse.getUserId()));
+    }
+
+    @Test
+    @DisplayName("[카카오 로그인] 로그인 성공")
+    void testLoginWithKakao() throws Exception {
+        String code = "fake-login-code";
+        when(kakaoAuthService.login(code)).thenReturn(loginResponse);
+
+        mockMvc.perform(get("/api/v1/auth/social/login/kakao")
+                        .param("code", code))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.accessToken").value(loginResponse.getAccessToken()))
+                .andExpect(jsonPath("$.data.userId").value(loginResponse.getUserId()));
+    }
+}

--- a/backend/src/test/java/com/pigma/harusari/common/oauth/service/KakaoAuthServiceImplTest.java
+++ b/backend/src/test/java/com/pigma/harusari/common/oauth/service/KakaoAuthServiceImplTest.java
@@ -93,7 +93,6 @@ class KakaoAuthServiceImplTest {
     @Test
     @DisplayName("[카카오 회원가입 - 사용자 조회] 정상 정보 반환")
     void testGetUserInfoSuccess() {
-        // given
         KakaoTokenResponse tokenResponse = KakaoTokenResponse.builder().accessToken(fakeAccessToken).build();
         KakaoUserInfo kakaoUserInfo = KakaoUserInfo.builder()
                 .id(123L)
@@ -103,14 +102,11 @@ class KakaoAuthServiceImplTest {
                         .build())
                 .build();
 
-        KakaoAuthServiceImpl spyService = Mockito.spy(kakaoAuthServiceImpl);
-        doReturn(tokenResponse).when(spyService).requestAccessToken(fakeCode);
-        doReturn(kakaoUserInfo).when(spyService).requestUserInfo(fakeAccessToken);
+        doReturn(tokenResponse).when(kakaoAuthServiceImpl).requestAccessToken(fakeCode);
+        doReturn(kakaoUserInfo).when(kakaoAuthServiceImpl).requestUserInfo(fakeAccessToken);
 
-        // when
-        KakaoUserBasicInfo info = spyService.getUserInfo(fakeCode);
+        KakaoUserBasicInfo info = kakaoAuthServiceImpl.getUserInfo(fakeCode);
 
-        // then
         assertThat(info.getEmail()).isEqualTo(email);
         assertThat(info.getNickname()).isEqualTo(nickname);
     }
@@ -118,7 +114,6 @@ class KakaoAuthServiceImplTest {
     @Test
     @DisplayName("[카카오 회원가입 - 사용자 조회] 사용자 정보 누락 예외")
     void testGetUserInfoMissingData() {
-        // given
         KakaoTokenResponse tokenResponse = KakaoTokenResponse.builder().accessToken(fakeAccessToken).build();
         KakaoUserInfo kakaoUserInfo = KakaoUserInfo.builder()
                 .id(123L)
@@ -128,12 +123,10 @@ class KakaoAuthServiceImplTest {
                         .build())
                 .build();
 
-        KakaoAuthServiceImpl spyService = Mockito.spy(kakaoAuthServiceImpl);
-        doReturn(tokenResponse).when(spyService).requestAccessToken(fakeCode);
-        doReturn(kakaoUserInfo).when(spyService).requestUserInfo(fakeAccessToken);
+        doReturn(tokenResponse).when(kakaoAuthServiceImpl).requestAccessToken(fakeCode);
+        doReturn(kakaoUserInfo).when(kakaoAuthServiceImpl).requestUserInfo(fakeAccessToken);
 
-        // when & then
-        assertThatThrownBy(() -> spyService.getUserInfo(fakeCode))
+        assertThatThrownBy(() -> kakaoAuthServiceImpl.getUserInfo(fakeCode))
                 .isInstanceOf(OAuthUserInfoIncompleteException.class)
                 .hasMessage(OAuthExceptionErrorCode.OAUTH_USER_INFO_INCOMPLETE.getErrorMessage());
     }
@@ -219,14 +212,13 @@ class KakaoAuthServiceImplTest {
                 .nickname(nickname)
                 .build();
 
-        KakaoAuthServiceImpl spyService = Mockito.spy(kakaoAuthServiceImpl);
-        doReturn(tokenResponse).when(spyService).requestAccessToken(fakeCode);
-        doReturn(kakaoUserInfo).when(spyService).requestUserInfo(fakeAccessToken);
-        doReturn(expectedResponse).when(spyService).issueJwtTokens(member);
+        doReturn(tokenResponse).when(kakaoAuthServiceImpl).requestAccessToken(fakeCode);
+        doReturn(kakaoUserInfo).when(kakaoAuthServiceImpl).requestUserInfo(fakeAccessToken);
+        doReturn(expectedResponse).when(kakaoAuthServiceImpl).issueJwtTokens(member);
         given(memberRepository.findByEmail(email)).willReturn(Optional.of(member));
 
         // when
-        LoginResponse actual = spyService.login(fakeCode);
+        LoginResponse actual = kakaoAuthServiceImpl.login(fakeCode);
 
         // then
         assertThat(actual.getAccessToken()).isEqualTo("jwtAccessToken");
@@ -237,7 +229,6 @@ class KakaoAuthServiceImplTest {
     @Test
     @DisplayName("[카카오 로그인] 이메일 기반 사용자 없을 시 예외 테스트")
     void testLoginUserNotFound() {
-        // given
         KakaoTokenResponse tokenResponse = KakaoTokenResponse.builder()
                 .accessToken(fakeAccessToken)
                 .build();
@@ -252,13 +243,11 @@ class KakaoAuthServiceImplTest {
                         .build())
                 .build();
 
-        KakaoAuthServiceImpl spyService = Mockito.spy(kakaoAuthServiceImpl);
-        doReturn(tokenResponse).when(spyService).requestAccessToken(fakeCode);
-        doReturn(kakaoUserInfo).when(spyService).requestUserInfo(fakeAccessToken);
+        doReturn(tokenResponse).when(kakaoAuthServiceImpl).requestAccessToken(fakeCode);
+        doReturn(kakaoUserInfo).when(kakaoAuthServiceImpl).requestUserInfo(fakeAccessToken);
         given(memberRepository.findByEmail(email)).willReturn(Optional.empty());
 
-        // when & then
-        assertThatThrownBy(() -> spyService.login(fakeCode))
+        assertThatThrownBy(() -> kakaoAuthServiceImpl.login(fakeCode))
                 .isInstanceOf(OAuthUserNotFoundException.class)
                 .hasMessage(OAuthExceptionErrorCode.OAUTH_USER_NOT_FOUND.getErrorMessage());
     }


### PR DESCRIPTION
Closes #59

## 🔥 작업 내용  
- 카카오 OAuth 연동 설정
  - application.yml에 Kakao OAuth 설정 항목 추가 (client-id, redirect-uri 등)
  - WebClient 설정을 위한 WebFlux 의존성 및 WebClientConfig 클래스 추가
- 카카오 로그인 및 회원가입 로직
  - GET /api/v1/auth/social/info/kakao : 인가 코드로 사용자 정보 조회
  - POST /api/v1/auth/social/signup/kakao : 사용자 정보를 기반으로 최종 회원가입 처리
  - GET /api/v1/auth/social/login/kakao : 기존 사용자인 경우 로그인 처리 및 JWT 발급
- 회원 엔티티 및 가입 흐름 확장
  - AuthProvider 필드 추가 (LOCAL / KAKAO 구분)
  - 성별(gender), 카테고리(categoryList) 정보도 일반 회원가입과 동일하게 입력 받도록 처리
  - KakaoSignupRequest DTO 확장 및 유효성 검증 추가

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [ ] 코드 리뷰 반영 완료

## ⚙️ 특이사항
- DDL 변경사항 반영 필수 (DB12-NOTE-02)
- .env 변경사항 반영 필수 (카카오API 관련 설정사항)

## ✨ 관련 이슈
- #59
