### PR TITLE
fix: 로그인 후 리다이렉트 및 회원가입 인증 흐름 버그 수정

### DIFF
--- a/frontend/src/features/category/router.js
+++ b/frontend/src/features/category/router.js
@@ -2,6 +2,7 @@ export const categoryRoutes = [
     {
         path: '/category',
         name: 'category',
-        component: () => import('@/features/category/views/CategoryView.vue')
+        component: () => import('@/features/category/views/CategoryView.vue'),
+        meta: { requiresGuest: true }
     }
 ]

--- a/frontend/src/features/category/router.js
+++ b/frontend/src/features/category/router.js
@@ -3,6 +3,6 @@ export const categoryRoutes = [
         path: '/category',
         name: 'category',
         component: () => import('@/features/category/views/CategoryView.vue'),
-        meta: { requiresGuest: true }
+        meta: { requiresAuth: true }
     }
 ]

--- a/frontend/src/features/main/router.js
+++ b/frontend/src/features/main/router.js
@@ -3,6 +3,6 @@ export const mainRoutes = [
         path: '/',
         name: 'main',
         component: () => import('@/features/main/views/MainPageView.vue'),
-        meta: { requiresGuest: true }
+        meta: { requiresAuth: true }
     }
 ]

--- a/frontend/src/features/main/router.js
+++ b/frontend/src/features/main/router.js
@@ -2,6 +2,7 @@ export const mainRoutes = [
     {
         path: '/',
         name: 'main',
-        component: () => import('@/features/main/views/MainPageView.vue')
+        component: () => import('@/features/main/views/MainPageView.vue'),
+        meta: { requiresGuest: true }
     }
 ]

--- a/frontend/src/features/statistics/router.js
+++ b/frontend/src/features/statistics/router.js
@@ -2,6 +2,7 @@ export const statisticsRoutes = [
     {
         path: '/statistics',
         name: 'statistics',
-        component: () => import('@/features/statistics/views/StatisticsView.vue')
+        component: () => import('@/features/statistics/views/StatisticsView.vue'),
+        meta: { requiresAuth: true }
     }
 ]

--- a/frontend/src/features/user/api.js
+++ b/frontend/src/features/user/api.js
@@ -1,3 +1,21 @@
 import api from '@/lib/axios';
 
-export const loginUser = (data) => api.post('/auth/login', data);
+export function loginUser(data) {
+  return api.post('/auth/login', data);
+}
+
+export function sendEmailCode(email) {
+  console.log("*** sendEmailCode 실행 ***")
+  console.log(email)
+  return api.post('/api/v1/auth/email/send', { email });
+}
+
+export function verifyEmailCode(email, code) {
+  return api.post('/api/v1/auth/email/verify', {
+    email, code
+  });
+}
+
+export function registerUser(payload) {
+  return api.post('/api/v1/auth/signup', payload);
+}

--- a/frontend/src/features/user/router.js
+++ b/frontend/src/features/user/router.js
@@ -2,17 +2,25 @@ export const userRoutes = [
     {
         path: '/signup',
         name: 'signup',
-        component: () => import('@/features/user/views/SignupView.vue')
+        component: () => import('@/features/user/views/SignupView.vue'),
+        meta: { requiresGuest: true }
     },
     {
         path: '/login',
         name: 'login',
         component: () => import('@/features/user/views/LoginView.vue'),
+        meta: { requiresGuest: true }
     },
     {
         path: '/signup',
         name: 'Signup',
         component: () => import('@/features/user/views/SignupView.vue'),
+        meta: { requiresGuest: true }
     },
-
+    {
+        path: '/signup/info',
+        name: 'SignupInfo',
+        component: () => import('@/features/user/views/SignupInfoView.vue'),
+        meta: { requiresGuest: true }
+    },
 ]

--- a/frontend/src/features/user/router.js
+++ b/frontend/src/features/user/router.js
@@ -9,4 +9,10 @@ export const userRoutes = [
         name: 'login',
         component: () => import('@/features/user/views/LoginView.vue'),
     },
+    {
+        path: '/signup',
+        name: 'Signup',
+        component: () => import('@/features/user/views/SignupView.vue'),
+    },
+
 ]

--- a/frontend/src/features/user/views/LoginView.vue
+++ b/frontend/src/features/user/views/LoginView.vue
@@ -23,7 +23,7 @@
           <router-link to="/signup">회원가입</router-link>
         </div>
         <div class="link-row">
-          <router-link to="/reset-password">비밀번호 재설정</router-link>
+          비밀번호 재설정
         </div>
       </div>
       <p class="error-message" v-if="error">{{ error }}</p>
@@ -32,7 +32,7 @@
 </template>
 
 <script setup>
-import { ref } from 'vue';
+import { ref, nextTick } from 'vue';
 import { useRouter, useRoute, RouterLink } from 'vue-router';
 import { useUserStore } from '@/stores/userStore';
 import { loginUser } from '@/features/user/api';
@@ -53,9 +53,20 @@ const handleLogin = async () => {
     const userData = data.data;
     userStore.setUser(userData);
 
+    // nextTick을 사용해 상태 반영 이후 라우터 실행
+    await nextTick();
+
     const redirectPath = route.query.redirect || '/';
-    if (redirectPath !== router.currentRoute.value.fullPath) {
-      await router.push(redirectPath);
+    const matchedRoute = router.resolve(redirectPath);
+
+    if (!matchedRoute.matched.length) {
+      console.warn('유효하지 않은 redirectPath:', redirectPath);
+      await router.push('/');
+    } else if (redirectPath !== router.currentRoute.value.fullPath) {
+      console.log("라우터 이동:", redirectPath);
+      setTimeout(() => {
+        router.push(redirectPath);
+      }, 0); // 이벤트 루프 한 틱 뒤에 실행
     }
   } catch (err) {
     error.value = '이메일 또는 비밀번호가 올바르지 않습니다.';

--- a/frontend/src/features/user/views/SignupInfoView.vue
+++ b/frontend/src/features/user/views/SignupInfoView.vue
@@ -1,0 +1,230 @@
+<template>
+  <Header/>
+  <div class="main-wrapper">
+    <div class="signup-box">
+      <div class="logo-box">
+        <img src="@/assets/images/HARURAMENSARI.png" alt="하루살이 로고" />
+      </div>
+      <div class="subtitle">이메일 인증을 통해 가입을 시작해보세요</div>
+      <div class="form-group">
+        <input type="email" v-model="email" placeholder="이메일 입력" />
+        <button @click="sendCode" :disabled="codeSent">
+          {{ codeSent ? '전송됨' : '인증번호 전송' }}
+        </button>
+      </div>
+      <div class="input-box" v-if="codeSent">
+        <input type="text" v-model="code" placeholder="인증번호 입력" />
+      </div>
+
+      <div class="input-box" v-if="codeSent">
+        <button class="submit-btn" @click="verifyCode">인증번호 확인</button>
+      </div>
+
+      <div class="input-box">
+        <input type="password" v-model="password" placeholder="비밀번호 입력" />
+      </div>
+      <div class="input-box">
+        <input type="password" v-model="confirmPassword" placeholder="비밀번호 확인" />
+      </div>
+
+      <div class="input-box">
+        <button class="submit-btn" @click="goNextStep">가입하기</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import { useRouter } from 'vue-router';
+import Header from '@/components/layout/Header.vue';
+import { sendEmailCode, verifyEmailCode } from '@/features/user/api';
+import { useSignupStore } from '@/stores/signupStore.js';
+import { showErrorToast, showSuccessToast } from '@/utill/toast.js';
+
+const router = useRouter();
+const signupStore = useSignupStore();
+
+const email = ref('');
+const code = ref('');
+const password = ref('');
+const confirmPassword = ref('');
+const codeSent = ref(false);
+const codeVerified = ref(false);
+
+const sendCode = async () => {
+  try {
+    console.log("===== email.value =====")
+    console.log(email.value);
+    await sendEmailCode(email.value);
+    console.log("await 종료?")
+    codeSent.value = true;
+    showSuccessToast('인증번호가 전송되었습니다.');
+  } catch (e) {
+    showErrorToast('인증번호 전송에 실패했습니다.');
+  }
+};
+
+const verifyCode = async () => {
+  try {
+    await verifyEmailCode(email.value, code.value);
+    codeVerified.value = true;
+    showSuccessToast('이메일 인증이 완료되었습니다.');
+  } catch (e) {
+    showErrorToast('인증번호가 올바르지 않습니다.');
+  }
+};
+
+const goNextStep = () => {
+  if (!email.value || !password.value || !confirmPassword.value) {
+    showErrorToast('모든 항목을 입력해주세요.');
+    return;
+  }
+  if (!codeVerified.value) {
+    showErrorToast('이메일 인증을 완료해주세요.');
+    return;
+  }
+  if (password.value.length < 10 || password.value.length > 20) {
+    showErrorToast('비밀번호는 10자 이상 20자 이하로 입력해주세요.');
+    return;
+  }
+  if (password.value !== confirmPassword.value) {
+    showErrorToast('비밀번호가 일치하지 않습니다.');
+    return;
+  }
+  signupStore.setBasicInfo({ email: email.value, password: password.value });
+  router.push('/signup/register');
+};
+</script>
+
+<style scoped>
+:root {
+  --header: #b8b8ff;
+  --background: #f8f7ff;
+  --button-add: #9381ff;
+  --button-save: #ffd8be;
+  --button-delete: #ffeeddd;
+  --card-bg: #ffffff;
+  --tag-purple: #cdb4db;
+  --tag-green: #b5ead7;
+  --tag-yellow: #fff1a8;
+}
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--background);
+  font-family: 'Segoe UI', sans-serif;
+}
+
+header {
+  width: 100%;
+  background: var(--header);
+  height: 85px;
+  display: flex;
+  align-items: center;
+}
+.header-inner {
+  width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.logo {
+  font-size: 30px;
+  font-weight: bold;
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+}
+.logo img {
+  height: 60px;
+  vertical-align: middle;
+  margin-right: 10px;
+}
+nav {
+  display: flex;
+  gap: 20px;
+}
+nav img {
+  height: 24px;
+  cursor: pointer;
+}
+
+.main-wrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: calc(100vh - 85px);
+  background: #f9f9f9;
+}
+.signup-box {
+  width: 400px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+.logo-box {
+  margin-bottom: 16px;
+}
+.logo-box img {
+  height: 80px;
+}
+.subtitle {
+  margin-bottom: 24px;
+  font-size: 16px;
+  color: #555;
+}
+.form-group {
+  display: flex;
+  width: 100%;
+  margin-bottom: 12px;
+}
+.form-group input {
+  padding: 12px;
+  font-size: 14px;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  flex: 1;
+}
+.form-group button {
+  margin-left: 8px;
+  padding: 12px 16px;
+  font-size: 14px;
+  border: none;
+  border-radius: 8px;
+  background-color: #716aca;
+  color: #fff;
+  cursor: pointer;
+}
+.input-box {
+  width: 100%;
+  margin-bottom: 12px;
+}
+.input-box input,
+.input-box button.submit-btn {
+  width: 100%;
+  box-sizing: border-box;
+}
+.input-box input {
+  padding: 12px;
+  font-size: 14px;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+}
+.submit-btn {
+  padding: 14px;
+  font-size: 16px;
+  font-weight: bold;
+  background: #f0f0f0;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  margin-top: 4px;
+}
+.submit-btn:hover {
+  background: #e2e2e2;
+}
+</style>

--- a/frontend/src/features/user/views/SignupView.vue
+++ b/frontend/src/features/user/views/SignupView.vue
@@ -6,14 +6,30 @@
         <img src="@/assets/images/HARURAMENSARI.png" alt="하루살이 로고" />
       </div>
       <div class="subtitle">지금 하루살이에 가입하고 오늘의 삶을 기록해보세요</div>
-      <button class="button">이메일 아이디로 가입하기</button>
-      <button class="button">카카오로 가입하기</button>
+      <button class="button" @click="goToEmailSignup">이메일 아이디로 가입하기</button>
+      <button class="button" @click="goToKakaoSignup">카카오로 가입하기</button>
     </div>
   </div>
 </template>
 
 <script setup>
-import Header from '@/components/layout/Header.vue';
+import { useRouter } from 'vue-router'
+import Header from '@/components/layout/Header.vue'
+
+const router = useRouter()
+
+const goToEmailSignup = () => {
+  router.push('/signup/info')
+}
+
+const goToKakaoSignup = () => {
+  const KAKAO_CLIENT_ID = import.meta.env.VITE_KAKAO_CLIENT_ID
+  const REDIRECT_URI = import.meta.env.VITE_KAKAO_REDIRECT_URI
+
+  const kakaoAuthUrl = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${KAKAO_CLIENT_ID}&redirect_uri=${REDIRECT_URI}`
+
+  window.location.href = kakaoAuthUrl
+}
 
 </script>
 

--- a/frontend/src/lib/axios.js
+++ b/frontend/src/lib/axios.js
@@ -28,9 +28,13 @@ api.interceptors.request.use((config) => {
     const token = localStorage.getItem('accessToken');
     console.log('[요청 인터셉터] accessToken:', token); // ✅ 추가
 
+    // 비로그인 상태에서 수행하는 로직인 경우는 삽입 X
     if (token) {
         config.headers.Authorization = `Bearer ${token}`;
+    } else {
+        delete config.headers.Authorization;
     }
+
     return config;
 });
 

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -21,17 +21,13 @@ router.beforeEach((to) => {
   const userStore = useUserStore();
   const isLoggedIn = userStore.isAuthenticated;
 
-  // 비회원도 접속 가능한 화면
-  const publicPages = ['/login', '/signup', '/reset-password'];
-  const authRequired = !publicPages.includes(to.path);
-
   // 회원만 접속 가능한 페이지이나 비로그인 상태 : 로그인 페이지로 이동
-  if (authRequired && !isLoggedIn) {
+  if (to.meta.requiresAuth && !isLoggedIn) {
     return { name: 'login', query: { redirect: to.fullPath } };
   }
 
   // 이미 로그인 된 상황에서 로그인 페이지에 접근하면 메인으로 이동
-  if (to.name === 'login' && isLoggedIn) {
+  if (to.meta.requiresGuest && isLoggedIn) {
     return { name: 'main' };
   }
 });

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,3 +1,4 @@
+import { nextTick } from 'vue';
 import { createRouter, createWebHistory } from 'vue-router';
 import { useUserStore } from "@/stores/userStore.js";
 
@@ -16,9 +17,18 @@ const router = createRouter({
   ],
 });
 
-// 비로그인 상태로 접근 시 차단하는 설정
-router.beforeEach((to) => {
+router.beforeEach(async (to, from) => {
   const userStore = useUserStore();
+
+  // 아직 초기화되지 않았는데 라우터가 먼저 작동한 경우를 대비
+  if (!userStore.accessToken) {
+    const savedUser = localStorage.getItem('user');
+    if (savedUser) {
+      userStore.setUser(JSON.parse(savedUser));
+      await nextTick(); // 상태 반영 대기
+    }
+  }
+
   const isLoggedIn = userStore.isAuthenticated;
 
   // 회원만 접속 가능한 페이지이나 비로그인 상태 : 로그인 페이지로 이동

--- a/frontend/src/stores/signupStore.js
+++ b/frontend/src/stores/signupStore.js
@@ -1,0 +1,46 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+
+export const useSignupStore = defineStore('signup', () => {
+  const email = ref('');
+  const password = ref('');
+  const nickname = ref('');
+  const gender = ref('NONE');
+  const consentPersonalInfo = ref(false);
+  const categoryList = ref([]);
+
+  function setBasicInfo({ emailValue, passwordValue }) {
+    email.value = emailValue;
+    password.value = passwordValue;
+  }
+
+  function setFinalInfo({ nicknameValue, genderValue, consent, categories }) {
+    nickname.value = nicknameValue;
+    gender.value = genderValue;
+    consentPersonalInfo.value = consent;
+    categoryList.value = categories;
+  }
+
+  function getSignupPayload() {
+    return {
+      email: email.value,
+      password: password.value,
+      nickname: nickname.value,
+      gender: gender.value,
+      consentPersonalInfo: consentPersonalInfo.value,
+      categoryList: categoryList.value.map(name => ({ categoryName: name }))
+    };
+  }
+
+  return {
+    email,
+    password,
+    nickname,
+    gender,
+    consentPersonalInfo,
+    categoryList,
+    setBasicInfo,
+    setFinalInfo,
+    getSignupPayload
+  };
+});

--- a/frontend/src/stores/userStore.js
+++ b/frontend/src/stores/userStore.js
@@ -1,5 +1,6 @@
 /* Pinia 설정 */
 import { defineStore } from 'pinia';
+import { jwtDecode } from 'jwt-decode';
 import api from '@/lib/axios.js';
 
 // 자동 로그아웃 기능을 위한 타이머 변수
@@ -24,11 +25,22 @@ export const useUserStore = defineStore('user', {
 
     actions: {
         setUser(userData) {
+            // accessToken에서 exp 추출
+            let expiration = null;
+            if (userData.accessToken) {
+                try {
+                    const decoded = jwtDecode(userData.accessToken);
+                    expiration = decoded.exp * 1000; // 초 → 밀리초
+                    console.log('🕒 decoded.expiration:', expiration);
+                } catch (e) {
+                    console.error('❌ JWT 디코딩 실패:', e);
+                }
+            }
             this.userId = userData.userId;
             this.email = userData.email;
             this.nickname = userData.nickname;
             this.accessToken = userData.accessToken;
-            this.expiration = userData.expiration;
+            this.expiration = expiration;
 
             localStorage.setItem('user', JSON.stringify(userData));
             localStorage.setItem('accessToken', userData.accessToken);


### PR DESCRIPTION
Closes #90

## 🔥 작업 내용  
- 로그인 이후에도 메인페이지로 이동하지 못하는 이슈 해결
: `accessToken`만 저장하고 `expiration`이 누락된 것이 원인으로, 로컬스토리지에도 만료시간 저장 포함하도록 수정
- JWT 만료시간(exp) 반영
   - `setUser()` 내에서 `jwtDecode()`를 통해 `expiration`을 계산하고 저장
   - 라우터 가드에서 `isAuthenticated`가 정상 작동하도록 수정
- 로그인 리다이렉트 개선
   - 로그인 직후 `nextTick()` 및 `setTimeout()`으로 라우터 이동 타이밍 안정화
   - 유효하지 않은 redirect 경로는 `/`로 fallback
- 회원가입 후 인증 상태 반영 버그 수정**
   - 회원가입 성공 후 동일한 흐름 적용으로 인증된 페이지 접근 가능

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인
- [x] 테스트 정상 동작 확인
- [ ] 코드 리뷰 반영 완료

## ⚙️ 특이사항
-각 컨텍스트 별 router.js 에서 라우팅 되는 페이지 별 meta: { requiresGuest: true } 또는meta: { requiresAuth: true } 추가하기

## ✨ 관련 이슈
- #87, #90
