### PR TITLE
feat: 일정 API 기능 개선 및 Swagger 문서화 적용

### DIFF
--- a/backend/src/main/java/com/pigma/harusari/task/automationSchedule/command/controller/AutomationScheduleController.java
+++ b/backend/src/main/java/com/pigma/harusari/task/automationSchedule/command/controller/AutomationScheduleController.java
@@ -4,6 +4,9 @@ import com.pigma.harusari.common.auth.model.CustomUserDetails;
 import com.pigma.harusari.common.dto.ApiResponse;
 import com.pigma.harusari.task.automationSchedule.command.dto.request.AutomationScheduleCreateRequest;
 import com.pigma.harusari.task.automationSchedule.command.service.AutomationScheduleServiceImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -13,11 +16,18 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
+@Tag(name = "자동화 일정 API", description = "자동화 일정 추가, 수정, 삭제 API")
 public class AutomationScheduleController {
 
     private final AutomationScheduleServiceImpl automationScheduleService;
 
     @PostMapping("/task/automationschedules")
+    @Operation(
+            summary = "자동화 일정 추가",
+            description = "카테고리ID, 자동화 내용, 종료 일시, 반복 주기, 반복 요일, 반복 일을 입력하면 자동화 일정이 추가된다."
+    )
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "자동화 일정 추가 요청 정보")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "자동화 일정이 성공적으로 추가된다.")
     public ResponseEntity<ApiResponse<Long>> createAutomationSchedule(
             @RequestBody @Valid AutomationScheduleCreateRequest request,
             @AuthenticationPrincipal CustomUserDetails userDetails
@@ -28,6 +38,10 @@ public class AutomationScheduleController {
     }
 
     @PutMapping("/task/automationschedules/{id}")
+    @Operation(summary = "자동화 일정 수정", description = "자동화 일정 ID와 수정할 내용을 입력하면 수정일 이후 자동화 일정이 수정된다.")
+    @Parameter(name = "id", description = "수정할 자동화 일정의 ID", example = "123")
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "자동화 일정 수정 요청 정보")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "자동화 일정이 성공적으로 수정된다.")
     public ResponseEntity<ApiResponse<Void>> updateSchedule(
             @PathVariable("id") Long scheduleId,
             @RequestBody @Valid AutomationScheduleCreateRequest request,
@@ -39,6 +53,9 @@ public class AutomationScheduleController {
     }
 
     @DeleteMapping("/task/automationschedules/{id}")
+    @Operation(summary = "자동화 일정 삭제", description = "지정한 자동화 일정 ID 삭제일 이후의 모든 일정을 삭제한다.")
+    @Parameter(name = "id", description = "삭제할 자동화 일정의 ID", example = "123")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "자동화 일정이 성공적으로 삭제된다.")
     public ResponseEntity<ApiResponse<Void>> deleteSchedulesAfter(
             @PathVariable("id") Long scheduleId,
             @AuthenticationPrincipal CustomUserDetails userDetails

--- a/backend/src/main/java/com/pigma/harusari/task/automationSchedule/command/controller/AutomationScheduleController.java
+++ b/backend/src/main/java/com/pigma/harusari/task/automationSchedule/command/controller/AutomationScheduleController.java
@@ -7,6 +7,7 @@ import com.pigma.harusari.task.automationSchedule.command.service.AutomationSche
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -26,7 +27,7 @@ public class AutomationScheduleController {
             summary = "자동화 일정 추가",
             description = "카테고리ID, 자동화 내용, 종료 일시, 반복 주기, 반복 요일, 반복 일을 입력하면 자동화 일정이 추가된다."
     )
-    @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "자동화 일정 추가 요청 정보")
+    @RequestBody(description = "자동화 일정 추가 요청 정보")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "자동화 일정이 성공적으로 추가된다.")
     public ResponseEntity<ApiResponse<Long>> createAutomationSchedule(
             @RequestBody @Valid AutomationScheduleCreateRequest request,
@@ -40,7 +41,7 @@ public class AutomationScheduleController {
     @PutMapping("/task/automationschedules/{id}")
     @Operation(summary = "자동화 일정 수정", description = "자동화 일정 ID와 수정할 내용을 입력하면 수정일 이후 자동화 일정이 수정된다.")
     @Parameter(name = "id", description = "수정할 자동화 일정의 ID", example = "123")
-    @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "자동화 일정 수정 요청 정보")
+    @RequestBody(description = "자동화 일정 수정 요청 정보")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "자동화 일정이 성공적으로 수정된다.")
     public ResponseEntity<ApiResponse<Void>> updateSchedule(
             @PathVariable("id") Long scheduleId,

--- a/backend/src/main/java/com/pigma/harusari/task/automationSchedule/query/controller/AutomationScheduleQueryController.java
+++ b/backend/src/main/java/com/pigma/harusari/task/automationSchedule/query/controller/AutomationScheduleQueryController.java
@@ -1,34 +1,38 @@
 package com.pigma.harusari.task.automationSchedule.query.controller;
 
 import com.pigma.harusari.common.auth.model.CustomUserDetails;
-import com.pigma.harusari.task.automationSchedule.command.dto.response.AutomationScheduleResponse;
-import com.pigma.harusari.task.automationSchedule.command.service.AutomationScheduleService;
+import com.pigma.harusari.common.dto.ApiResponse;
 import com.pigma.harusari.task.automationSchedule.query.dto.request.AutomationScheduleRequest;
 import com.pigma.harusari.task.automationSchedule.query.dto.response.AutomationScheduleDto;
 import com.pigma.harusari.task.automationSchedule.query.service.AutomationScheduleQueryService;
-import com.pigma.harusari.task.schedule.command.entity.Schedule;
-import com.pigma.harusari.task.schedule.command.repository.ScheduleRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.time.LocalDate;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1")
+@Tag(name = "자동화 일정 조회 API", description = "자동화 일정의 카테고리, 반복 주기, 그리고 검색일 이후 가장 가까운 일정을 조회하는 API")
 public class AutomationScheduleQueryController {
 
     private final AutomationScheduleQueryService automationScheduleQueryService;
-    private final AutomationScheduleService automationScheduleService;
-    private final ScheduleRepository scheduleRepository;
 
     @GetMapping("/task/automationschedules")
+    @Operation(
+            summary = "자동화 일정 목록 조회", description = "검색 조건(예: 카테고리, 반복 주기)에 따라 자동화 일정 목록을 조회한다."
+    )
+    @Parameters({
+            @Parameter(name = "categoryId", description = "조회할 카테고리 ID", example = "1"),
+            @Parameter(name = "repeatType", description = "조회할 반복 주기", example = "MONTHLY")
+    })
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "자동화 일정 목록을 반환한다.")
     public ResponseEntity<List<AutomationScheduleDto>> getAutomationSchedules(
             AutomationScheduleRequest request,
             @AuthenticationPrincipal CustomUserDetails userDetails
@@ -39,27 +43,18 @@ public class AutomationScheduleQueryController {
     }
 
     @GetMapping("/task/automationschedules/nearest")
-    public ResponseEntity<Map<String, Object>> getNearestSchedule(
+    @Operation(
+            summary = "가장 가까운 자동화 일정 조회", description = "지정한 자동화 일정 ID를 기준으로, 오늘 이후 가장 가까운 일정을 반환한다."
+    )
+    @Parameter(name = "automationScheduleId", description = "조회할 자동화 일정 ID", example = "1")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "가장 가까운 자동화 일정 정보 반환")
+    public ResponseEntity<ApiResponse<AutomationScheduleDto>> getNearestSchedule(
             @RequestParam("automationScheduleId") Long automationScheduleId,
-            @RequestParam("baseDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate baseDate,
             @AuthenticationPrincipal CustomUserDetails userDetails
-    ){
+    ) {
         Long memberId = userDetails.getMemberId();
-
-        // 1. 기존 자동화 일정 조회 (memberId로 소유자 검증 등)
-        AutomationScheduleResponse scheduleDto = automationScheduleService.getAutomationSchedule(automationScheduleId, memberId);
-
-        // 2. 가장 가까운 일정 조회
-        Schedule nearest = scheduleRepository
-                .findFirstByAutomationSchedule_AutomationScheduleIdAndScheduleDateGreaterThanEqualOrderByScheduleDateAsc(automationScheduleId, baseDate)
-                .orElse(null);
-
-        // 3. Map에 담아 반환
-        Map<String, Object> result = new HashMap<>();
-        result.put("automationSchedule", scheduleDto);
-        result.put("nearestSchedule", nearest);
-
-        return ResponseEntity.ok(result);
+        AutomationScheduleDto dto = automationScheduleQueryService.getNearestAutomationSchedule(automationScheduleId, memberId);
+        return ResponseEntity.ok(ApiResponse.success(dto));
     }
 
 }

--- a/backend/src/main/java/com/pigma/harusari/task/automationSchedule/query/dto/request/AutomationScheduleRequest.java
+++ b/backend/src/main/java/com/pigma/harusari/task/automationSchedule/query/dto/request/AutomationScheduleRequest.java
@@ -8,11 +8,11 @@ public class AutomationScheduleRequest {
 
     private final Long categoryId;
 
-    private String repeatType;
+    private final String repeatType;
 
     private final Long automationScheduleId;
 
-    private String automationScheduleContent;
+    private final String automationScheduleContent;
 
     private final String categoryName;
 
@@ -27,6 +27,5 @@ public class AutomationScheduleRequest {
         this.automationScheduleContent = automationScheduleContent;
         this.categoryName = categoryName;
     }
-
 
 }

--- a/backend/src/main/java/com/pigma/harusari/task/automationSchedule/query/dto/response/AutomationScheduleDto.java
+++ b/backend/src/main/java/com/pigma/harusari/task/automationSchedule/query/dto/response/AutomationScheduleDto.java
@@ -4,6 +4,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+
 @NoArgsConstructor
 @Getter
 public class AutomationScheduleDto {
@@ -18,14 +20,17 @@ public class AutomationScheduleDto {
 
     private String categoryName;
 
+    private LocalDate scheduleDate;
+
 
     @Builder
     public AutomationScheduleDto(
-            Long automationScheduleId, String automationScheduleContent, String repeatType,
+            Long automationScheduleId, String automationScheduleContent, LocalDate scheduleDate, String repeatType,
             Long categoryId, String categoryName
     ) {
         this.automationScheduleId = automationScheduleId;
         this.automationScheduleContent = automationScheduleContent;
+        this.scheduleDate = scheduleDate;
         this.repeatType = repeatType;
         this.categoryId = categoryId;
         this.categoryName = categoryName;

--- a/backend/src/main/java/com/pigma/harusari/task/automationSchedule/query/service/AutomationScheduleQueryService.java
+++ b/backend/src/main/java/com/pigma/harusari/task/automationSchedule/query/service/AutomationScheduleQueryService.java
@@ -9,4 +9,5 @@ public interface AutomationScheduleQueryService {
 
     List<AutomationScheduleDto> getAutomationScheduleList(AutomationScheduleRequest request, Long memberId);
 
+    AutomationScheduleDto getNearestAutomationSchedule(Long automationScheduleId, Long memberId);
 }

--- a/backend/src/main/java/com/pigma/harusari/task/automationSchedule/query/service/AutomationScheduleQueryServiceImpl.java
+++ b/backend/src/main/java/com/pigma/harusari/task/automationSchedule/query/service/AutomationScheduleQueryServiceImpl.java
@@ -3,10 +3,15 @@ package com.pigma.harusari.task.automationSchedule.query.service;
 import com.pigma.harusari.task.automationSchedule.query.dto.request.AutomationScheduleRequest;
 import com.pigma.harusari.task.automationSchedule.query.dto.response.AutomationScheduleDto;
 import com.pigma.harusari.task.automationSchedule.query.mapper.AutomationScheduleMapper;
+import com.pigma.harusari.task.exception.ScheduleNotFoundException;
+import com.pigma.harusari.task.exception.TaskErrorCode;
+import com.pigma.harusari.task.schedule.command.entity.Schedule;
+import com.pigma.harusari.task.schedule.command.repository.ScheduleRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -14,10 +19,32 @@ import java.util.List;
 public class AutomationScheduleQueryServiceImpl implements AutomationScheduleQueryService {
 
     private final AutomationScheduleMapper automationScheduleMapper;
+    private final ScheduleRepository scheduleRepository;
 
     @Transactional(readOnly = true)
     public List<AutomationScheduleDto> getAutomationScheduleList(AutomationScheduleRequest request, Long memberId) {
         return automationScheduleMapper.selectAutomationScheduleList(request, memberId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public AutomationScheduleDto getNearestAutomationSchedule(Long automationScheduleId, Long memberId) {
+        LocalDate baseDate = LocalDate.now();
+
+        Schedule nearest = scheduleRepository
+                .findFirstByAutomationSchedule_AutomationScheduleIdAndScheduleDateGreaterThanEqualOrderByScheduleDateAsc(
+                        automationScheduleId, baseDate
+                )
+                .orElseThrow(() -> new ScheduleNotFoundException(TaskErrorCode.SCHEDULE_NOT_FOUND));
+
+        return AutomationScheduleDto.builder()
+                .automationScheduleId(nearest.getAutomationSchedule().getAutomationScheduleId())
+                .automationScheduleContent(nearest.getAutomationSchedule().getAutomationScheduleContent())
+                .scheduleDate(nearest.getScheduleDate())
+                .repeatType(nearest.getAutomationSchedule().getRepeatType().name())
+                .categoryId(nearest.getAutomationSchedule().getCategoryId())
+                .categoryName(nearest.getCategory().getCategoryName())
+                .build();
     }
 
 }

--- a/backend/src/main/java/com/pigma/harusari/task/schedule/command/controller/ScheduleCommandController.java
+++ b/backend/src/main/java/com/pigma/harusari/task/schedule/command/controller/ScheduleCommandController.java
@@ -2,27 +2,35 @@ package com.pigma.harusari.task.schedule.command.controller;
 
 import com.pigma.harusari.common.auth.model.CustomUserDetails;
 import com.pigma.harusari.common.dto.ApiResponse;
+import com.pigma.harusari.task.exception.InvalidRepeatTypeException;
+import com.pigma.harusari.task.exception.NeedLoginException;
+import com.pigma.harusari.task.exception.TaskErrorCode;
 import com.pigma.harusari.task.schedule.command.dto.request.CompletionStatusUpdateRequest;
 import com.pigma.harusari.task.schedule.command.dto.request.ScheduleCreateRequest;
 import com.pigma.harusari.task.schedule.command.dto.request.ScheduleUpdateRequest;
 import com.pigma.harusari.task.schedule.command.dto.response.ScheduleCommandResponse;
 import com.pigma.harusari.task.schedule.command.service.ScheduleCommandService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
+@Tag(name = "일정 API", description = "일정 추가, 수정, 삭제 API")
 public class ScheduleCommandController {
 
     private final ScheduleCommandService scheduleCommandService;
 
     @PostMapping("/task/schedule")
+    @Operation(summary = "일정 생성", description = "일정 생성 요청 정보를 입력받아 새로운 일정을 등록한다.")
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "일정 생성 요청 정보")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "생성된 일정의 ID를 반환합니다.")
     public ResponseEntity<ApiResponse<Long>> createSchedule(
             @RequestBody @Valid ScheduleCreateRequest scheduleCreateRequest,
             @AuthenticationPrincipal CustomUserDetails userDetails
@@ -34,17 +42,21 @@ public class ScheduleCommandController {
     }
 
     @PutMapping("/task/schedule/{scheduleId}")
+    @Operation(summary = "일정 수정", description = "일정 ID와 수정 요청 정보를 입력받아 일정을 수정한다.")
+    @Parameter(name = "scheduleId", description = "수정할 일정의 ID", example = "123")
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "일정 수정 요청 정보")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "일정이 성공적으로 수정된다.")
     public ResponseEntity<ApiResponse<Long>> updateSchedule(
             @PathVariable Long scheduleId,
             @RequestBody @Valid ScheduleUpdateRequest scheduleUpdateRequest,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         if (userDetails == null) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
+            throw new NeedLoginException(TaskErrorCode.NEED_LOGIN);
         }
         Long memberId = userDetails.getMemberId();
         if (memberId == null) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "회원 정보가 올바르지 않습니다.");
+            throw new InvalidRepeatTypeException(TaskErrorCode.INVALID_MEMBER_INFO);
         }
 
         Long updatedId = userDetails.getMemberId();
@@ -53,16 +65,19 @@ public class ScheduleCommandController {
     }
 
     @DeleteMapping("/task/schedule/{scheduleId}")
+    @Operation(summary = "일정 삭제", description = "일정 ID를 입력받아 해당 일정을 삭제한다.")
+    @Parameter(name = "scheduleId", description = "삭제할 일정의 ID", example = "123")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "일정이 성공적으로 삭제된다.")
     public ResponseEntity<ApiResponse<Void>> deleteSchedule(
             @PathVariable Long scheduleId,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         if (userDetails == null) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
+            throw new NeedLoginException(TaskErrorCode.NEED_LOGIN);
         }
         Long memberId = userDetails.getMemberId();
         if (memberId == null) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "회원 정보가 올바르지 않습니다.");
+            throw new InvalidRepeatTypeException(TaskErrorCode.INVALID_MEMBER_INFO);
         }
 
         scheduleCommandService.deleteSchedule(scheduleId, memberId);
@@ -70,17 +85,21 @@ public class ScheduleCommandController {
     }
 
     @PutMapping("/task/schedule/{scheduleId}/completionstatus")
+    @Operation(summary = "일정 완료 상태 수정", description = "일정 ID와 완료 상태 값을 입력받아 해당 일정의 완료 상태를 수정한다.")
+    @Parameter(name = "scheduleId", description = "완료 상태를 수정할 일정의 ID", example = "123")
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "완료 상태 수정 요청 정보 (completionStatus: true/false)")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "수정된 일정의 정보를 반환한다.")
     public ResponseEntity<ApiResponse<ScheduleCommandResponse>> updateCompletionStatus(
             @PathVariable Long scheduleId,
             @RequestBody @Valid CompletionStatusUpdateRequest request,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         if (userDetails == null) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
+            throw new NeedLoginException(TaskErrorCode.NEED_LOGIN);
         }
         Long memberId = userDetails.getMemberId();
         if (memberId == null) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "회원 정보가 올바르지 않습니다.");
+            throw new InvalidRepeatTypeException(TaskErrorCode.INVALID_MEMBER_INFO);
         }
 
         ScheduleCommandResponse response = scheduleCommandService.updateCompletionStatus(

--- a/backend/src/main/java/com/pigma/harusari/task/schedule/command/controller/ScheduleCommandController.java
+++ b/backend/src/main/java/com/pigma/harusari/task/schedule/command/controller/ScheduleCommandController.java
@@ -12,6 +12,7 @@ import com.pigma.harusari.task.schedule.command.dto.response.ScheduleCommandResp
 import com.pigma.harusari.task.schedule.command.service.ScheduleCommandService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +30,7 @@ public class ScheduleCommandController {
 
     @PostMapping("/task/schedule")
     @Operation(summary = "일정 생성", description = "일정 생성 요청 정보를 입력받아 새로운 일정을 등록한다.")
-    @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "일정 생성 요청 정보")
+    @RequestBody(description = "일정 생성 요청 정보")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "생성된 일정의 ID를 반환합니다.")
     public ResponseEntity<ApiResponse<Long>> createSchedule(
             @RequestBody @Valid ScheduleCreateRequest scheduleCreateRequest,
@@ -44,7 +45,7 @@ public class ScheduleCommandController {
     @PutMapping("/task/schedule/{scheduleId}")
     @Operation(summary = "일정 수정", description = "일정 ID와 수정 요청 정보를 입력받아 일정을 수정한다.")
     @Parameter(name = "scheduleId", description = "수정할 일정의 ID", example = "123")
-    @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "일정 수정 요청 정보")
+    @RequestBody(description = "일정 수정 요청 정보")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "일정이 성공적으로 수정된다.")
     public ResponseEntity<ApiResponse<Long>> updateSchedule(
             @PathVariable Long scheduleId,
@@ -87,7 +88,7 @@ public class ScheduleCommandController {
     @PutMapping("/task/schedule/{scheduleId}/completionstatus")
     @Operation(summary = "일정 완료 상태 수정", description = "일정 ID와 완료 상태 값을 입력받아 해당 일정의 완료 상태를 수정한다.")
     @Parameter(name = "scheduleId", description = "완료 상태를 수정할 일정의 ID", example = "123")
-    @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "완료 상태 수정 요청 정보 (completionStatus: true/false)")
+    @RequestBody(description = "완료 상태 수정 요청 정보 (completionStatus: true/false)")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "수정된 일정의 정보를 반환한다.")
     public ResponseEntity<ApiResponse<ScheduleCommandResponse>> updateCompletionStatus(
             @PathVariable Long scheduleId,

--- a/backend/src/main/java/com/pigma/harusari/task/schedule/command/dto/response/ScheduleCommandResponse.java
+++ b/backend/src/main/java/com/pigma/harusari/task/schedule/command/dto/response/ScheduleCommandResponse.java
@@ -15,6 +15,8 @@ public class ScheduleCommandResponse {
 
     private Long categoryId;
 
+    private String categoryName;
+
     private String scheduleContent;
 
     private LocalDate scheduleDate;

--- a/backend/src/main/java/com/pigma/harusari/task/schedule/query/controller/ScheduleQueryController.java
+++ b/backend/src/main/java/com/pigma/harusari/task/schedule/query/controller/ScheduleQueryController.java
@@ -7,6 +7,10 @@ import com.pigma.harusari.task.exception.NeedLoginException;
 import com.pigma.harusari.task.exception.TaskErrorCode;
 import com.pigma.harusari.task.schedule.query.dto.response.ScheduleListResponse;
 import com.pigma.harusari.task.schedule.query.service.ScheduleQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -17,11 +21,19 @@ import java.time.LocalDate;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1")
+@Tag(name = "일정 조회 API", description = "카테고리, 특정 날짜로 일정을 조회하는 API")
+
 public class ScheduleQueryController {
 
     private final ScheduleQueryService scheduleQueryService;
 
     @GetMapping("/task/schedule")
+    @Operation(summary = "일정 목록 조회", description = "카테고리 ID와 일정 날짜(옵션)를 입력받아 해당 조건에 맞는 일정 목록을 조회한다.")
+    @Parameters({
+            @Parameter(name = "categoryId", description = "조회할 카테고리 ID (선택)", example = "1"),
+            @Parameter(name = "scheduleDate", description = "조회할 일정 날짜 (yyyy-MM-dd, 선택)", example = "2025-06-01")
+    })
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조건에 맞는 일정 목록을 반환합니다.")
     public ResponseEntity<ApiResponse<ScheduleListResponse>> getScheduleList(
             @RequestParam(value = "categoryId", required = false) Long categoryId,
             @RequestParam(value = "scheduleDate", required = false) LocalDate scheduleDate,

--- a/backend/src/main/resources/mappers/schedule/AutomationScheduleMapper.xml
+++ b/backend/src/main/resources/mappers/schedule/AutomationScheduleMapper.xml
@@ -9,9 +9,12 @@
         a.repeat_type AS repeatType,
         c.category_id AS categoryId,
         c.category_name AS categoryName,
-        a.automation_schedule_content AS automationScheduleContent
+        a.automation_schedule_content AS automationScheduleContent,
+        s.schedule_date AS scheduleDate
         FROM automation_schedule a
         JOIN category c ON a.category_id = c.category_id
+        JOIN
+        schedule s ON a.automation_schedule_id = s.automation_schedule_id
         <where>
             c.member_id = #{memberId}
             <if test="request.repeatType != null">


### PR DESCRIPTION
Closes #105 

## 🔥 작업 내용  
- 일정 생성, 수정, 삭제, 완료 상태 변경, 목록 조회 API에 Swagger(OpenAPI) 문서화 어노테이션 추가
- 인증 및 예외 처리 로직 명확화
- 응답 DTO 및 파라미터 설명, 예시 데이터 보강
- scheduleDate 등 주요 필드 반환 구조 개선

## ✅ 체크 리스트  
- [ ] 기능 정상 동작 확인
- [ ] 테스트 정상 동작 확인
- [ ] 코드 리뷰 반영 완료

## ✨ 관련 이슈
- #105 
